### PR TITLE
Unsynced filters after bulk validation

### DIFF
--- a/pages/[project]/changes_logs.vue
+++ b/pages/[project]/changes_logs.vue
@@ -111,6 +111,7 @@ function removeLogs(loChaIds?: number[]) {
       (loChaId) => loCha.id === loChaId,
     ) === -1)
 
+  logs.value = loChas.value.map((loCha) => loCha.objects).flat()
   project.value!.to_be_validated = logs.value?.length
 }
 


### PR DESCRIPTION
I opened [this issue](https://github.com/teritorio/clearance-frontend/issues/232) to handle the case of user is validating everything at once.
He would be facing this screen:
![image](https://github.com/user-attachments/assets/bcdf1a8a-c2da-4f1b-8f0d-71eb24a3a19e)