### PR TITLE
chore: replace underscore with native JS

### DIFF
--- a/components/Diff.vue
+++ b/components/Diff.vue
@@ -3,7 +3,6 @@ import type { Change } from 'diff'
 import type { PropType } from 'vue'
 import type { Actions, Key } from '~/libs/types'
 import { diffChars } from 'diff'
-import _ from 'underscore'
 import { maxActionPriority } from '~/libs/types'
 
 export default defineNuxtComponent({
@@ -34,15 +33,19 @@ export default defineNuxtComponent({
 
   computed: {
     groupedKeys(): string[][] {
-      const keys: string[] = _.sortBy(
-        _.uniq([...Object.keys(this.src || {}), ...Object.keys(this.dst)]),
-        (key) => (this.diff[key] ? -maxActionPriority(this.diff[key]) : 0),
-      )
+      const keys: string[] = [...new Set([...Object.keys(this.src || {}), ...Object.keys(this.dst)])]
+        .toSorted((a, b) => {
+          const pa = this.diff[a] ? -maxActionPriority(this.diff[a]) : 0
+          const pb = this.diff[b] ? -maxActionPriority(this.diff[b]) : 0
+          return pa - pb
+        })
 
-      return Object.values(
-        _.groupBy(keys, (key) =>
-          this.diff[key]?.map((diff) => `${diff}`)?.join('||')),
-      )
+      const grouped: Record<string, string[]> = {}
+      for (const key of keys) {
+        const groupKey = this.diff[key]?.map((diff) => `${diff}`)?.join('||') ?? ''
+        ;(grouped[groupKey] ??= []).push(key)
+      }
+      return Object.values(grouped)
     },
   },
 

--- a/components/LogFilters.vue
+++ b/components/LogFilters.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { LocationQuery } from 'vue-router'
 import type { Log } from '~/libs/types'
-import { countBy, indexBy, sortBy, uniq } from 'underscore'
 
 //
 // Props
@@ -33,27 +32,27 @@ watchEffect(() => {
 const stats = computed(() => {
   const actions = props.logs
     .map((log) =>
-      uniq(
+      [...new Set(
         [
           ...Object.values(log.diff_attribs || {}),
           ...Object.values(log.diff_tags || {}),
         ]
           .flat(1)
           .map((action) => action[0]),
-      ),
+      )],
     )
     .flat(1)
   return getStats(actions)
 })
 
 const statSelectors = computed(() => {
-  const matches = props.logs.map((log) => uniq(log.matches).flat()).flat(1)
+  const matches = props.logs.map((log) => [...new Set(log.matches)].flat()).flat(1)
   return getStats(matches, (m) => m.selectors.join(';'))
 })
 
 const statUserGroups = computed(() => {
   const userGroups = props.logs
-    .map((log) => uniq(log.matches.map((m) => m.user_groups).flat(2)))
+    .map((log) => [...new Set(log.matches.map((m) => m.user_groups).flat(2))])
     .flat(1)
   return getStats(userGroups)
 })
@@ -61,11 +60,11 @@ const statUserGroups = computed(() => {
 const statUsers = computed(() => {
   const users = props.logs
     .map((log) =>
-      uniq(
+      [...new Set(
         (log.changesets ? log.base ? log.changesets.slice(1) : log.changesets : []).map(
           (changeset) => changeset.user,
         ),
-      ),
+      )],
     )
     .flat(2)
   return getStats(users)
@@ -77,11 +76,18 @@ const statDates = computed(() => {
 })
 
 function getStats<Type>(data: Type[], key: (o: Type) => string = (i) => `${i}`): [Type, number][] {
-  const index = indexBy(data, key)
-  return sortBy(
-    Object.entries(countBy(data, key)) as [string, number][],
-    ([_key, count]) => -count,
-  ).map(([key, count]) => [index[key], count])
+  const index = new Map<string, Type>()
+  const counts = new Map<string, number>()
+  for (const item of data) {
+    const k = key(item)
+    if (!index.has(k)) {
+      index.set(k, item)
+    }
+    counts.set(k, (counts.get(k) || 0) + 1)
+  }
+  return [...counts.entries()]
+    .toSorted(([, a], [, b]) => b - a)
+    .map(([k, count]) => [index.get(k)!, count])
 }
 
 const router = useRouter()

--- a/components/LogItem.vue
+++ b/components/LogItem.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { Log, ObjType } from '~/libs/types'
-import { compact, uniq } from 'underscore'
 import LazyComponent from 'v-lazy-component'
 import { objTypeFull } from '~/libs/types'
 
@@ -19,12 +18,19 @@ function objtypeFull(objtype: ObjType) {
 }
 
 function uniqHistoryIds(log: Log) {
-  return uniq(
-    compact([log.base, log.change])
-      .filter((object) => object.id !== null)
-      .map((object) => ({ objtype: object.objtype, id: object.id })),
-    (object) => `${object.objtype}${object.id}`,
-  )
+  const items = [log.base, log.change]
+    .filter((object): object is NonNullable<typeof object> => !!object)
+    .filter((object) => object.id !== null)
+    .map((object) => ({ objtype: object.objtype, id: object.id }))
+  const seen = new Set<string>()
+  return items.filter((object) => {
+    const key = `${object.objtype}${object.id}`
+    if (seen.has(key)) {
+      return false
+    }
+    seen.add(key)
+    return true
+  })
 }
 </script>
 

--- a/components/UserGroups.vue
+++ b/components/UserGroups.vue
@@ -10,7 +10,6 @@ import {
   LngLatBounds,
   Map,
 } from 'maplibre-gl'
-import _ from 'underscore'
 
 const colors = ['#2364AA', '#EA7317', '#73BFB8', '#FEC601', '#3DA5D9']
 
@@ -56,7 +55,7 @@ export default defineNuxtComponent({
     Promise.all(fetchAllPolygons).then((allPolygons) => {
       const geojson = {
         type: 'FeatureCollection',
-        features: _.compact(allPolygons),
+        features: allPolygons.filter(Boolean),
       } as FeatureCollection
       const bounds = new LngLatBounds(
         bbox(geojson) as [number, number, number, number],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "diff": "^8.0.4",
     "element-plus": "^2.7.1",
     "maplibre-gl": "^4.1.2",
-    "underscore": "^1.13.6",
     "v-lazy-component": "^3.0.9",
     "vue": "^3.4.22"
   },
@@ -37,7 +36,6 @@
     "@nuxt/eslint": "^0.5.7",
     "@nuxtjs/i18n": "^8.3.0",
     "@types/node": "^22.0.0",
-    "@types/underscore": "^1.11.15",
     "babel-jest": "^29.7.0",
     "eslint": "^9.9.0",
     "jest": "^29.7.0",

--- a/pages/[project]/changes_logs.vue
+++ b/pages/[project]/changes_logs.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { Geometry } from 'geojson'
-import { uniq } from 'underscore'
 
 //
 // Validators
@@ -55,11 +54,11 @@ const loChasWithFilter = computed(() => {
     loCha.objects.some((log) => {
       const changesetsUsers
       = route.query.filterByUsers !== undefined
-      && uniq(
+      && [...new Set(
         (log.changesets ? log.base ? log.changesets.slice(1) : log.changesets : []).map(
           (changeset) => changeset.user,
         ),
-      )
+      )]
       return (
         (route.query.filterByAction === undefined
           || Object.values(log.diff_attribs || {})

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,15 +1,16 @@
 <script setup lang="ts">
 import type { Project } from '~/libs/types'
-import _ from 'underscore'
 
 const user = useUser()
 const projects = useProjects()
 const myProjects = ref<Project[]>()
 const otherProjects = ref<Project[]>()
 
-const [my, other] = _.partition(
-  projects.value,
+const my = (projects.value || []).filter(
   (project: Project) => user.value?.projects.includes(project.id) || false,
+)
+const other = (projects.value || []).filter(
+  (project: Project) => !(user.value?.projects.includes(project.id) || false),
 )
 myProjects.value = my
 otherProjects.value = other

--- a/yarn.lock
+++ b/yarn.lock
@@ -3621,13 +3621,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/underscore@npm:^1.11.15":
-  version: 1.13.0
-  resolution: "@types/underscore@npm:1.13.0"
-  checksum: 10c0/240d3f36f694e177b1896c464b1254249e64b51a2afc703a1dda61f0c544d6e3b081ac4d955fb057e873982a62a7ba78e3a0aaa252c9d766f6cbe5e85283bc04
-  languageName: node
-  linkType: hard
-
 "@types/unist@npm:*, @types/unist@npm:^3.0.0":
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
@@ -12996,13 +12989,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"underscore@npm:^1.13.6":
-  version: 1.13.7
-  resolution: "underscore@npm:1.13.7"
-  checksum: 10c0/fad2b4aac48847674aaf3c30558f383399d4fdafad6dd02dd60e4e1b8103b52c5a9e5937e0cc05dacfd26d6a0132ed0410ab4258241240757e4a4424507471cd
-  languageName: node
-  linkType: hard
-
 "undici-types@npm:~6.20.0":
   version: 6.20.0
   resolution: "undici-types@npm:6.20.0"
@@ -13829,7 +13815,6 @@ __metadata:
     "@turf/helpers": "npm:^7.3.4"
     "@types/geojson": "npm:^7946.0.14"
     "@types/node": "npm:^22.0.0"
-    "@types/underscore": "npm:^1.11.15"
     babel-jest: "npm:^29.7.0"
     dayjs: "npm:^1.11.20"
     diff: "npm:^8.0.4"
@@ -13843,7 +13828,6 @@ __metadata:
     postcss-html: "npm:^1.8.1"
     simple-git-hooks: "npm:^2.13.1"
     typescript: "npm:5.6.3"
-    underscore: "npm:^1.13.6"
     v-lazy-component: "npm:^3.0.9"
     vite: "npm:^5.2.9"
     vue: "npm:^3.4.22"


### PR DESCRIPTION
## Summary
- Replace all underscore utility functions (`compact`, `uniq`, `sortBy`, `groupBy`, `countBy`, `indexBy`, `partition`) with native JavaScript equivalents
- Remove `underscore` and `@types/underscore` from dependencies
- Uses modern JS features: `Set`, `Map`, `.toSorted()`, `.filter(Boolean)`, `Object.values()`

## Changes
| File | Before | After |
|------|--------|-------|
| `UserGroups.vue` | `_.compact()` | `.filter(Boolean)` |
| `LogItem.vue` | `compact()`, `uniq(…, iteratee)` | Type-narrowing filter, `Set`-based dedup |
| `LogFilters.vue` | `countBy`, `indexBy`, `sortBy`, `uniq` | `Map`-based `getStats()`, `[...new Set()]` |
| `Diff.vue` | `_.sortBy`, `_.uniq`, `_.groupBy` | `.toSorted()`, `Set`, manual grouping |
| `pages/index.vue` | `_.partition` | Two `.filter()` calls |
| `changes_logs.vue` | `uniq()` | `[...new Set()]` |

## Test plan
- [x] TypeScript typecheck passes
- [x] Build succeeds
- [x] ESLint passes
- [ ] CI passes

Closes #308