### PR TITLE
refactor: convert Options API components to Composition API

### DIFF
--- a/components/Changesets.vue
+++ b/components/Changesets.vue
@@ -1,25 +1,11 @@
-<script lang="ts">
-import type { PropType } from 'vue'
+<script setup lang="ts">
 import type { Changeset } from '~/libs/types'
 
-export default defineNuxtComponent({
-  name: 'Changesets',
+defineProps<{
+  changesets: Changeset[]
+}>()
 
-  props: {
-    changesets: {
-      type: Array as PropType<Changeset[]>,
-      required: true,
-    },
-  },
-
-  data(): {
-    accordion: Ref<string>
-  } {
-    return {
-      accordion: ref('0'),
-    }
-  },
-})
+const accordion = ref('0')
 </script>
 
 <template>

--- a/components/Diff.vue
+++ b/components/Diff.vue
@@ -1,84 +1,63 @@
-<script lang="ts">
+<script setup lang="ts">
 import type { Change } from 'diff'
-import type { PropType } from 'vue'
 import type { Actions, Key } from '~/libs/types'
 import { diffChars } from 'diff'
 import _ from 'underscore'
 import { maxActionPriority } from '~/libs/types'
 
-export default defineNuxtComponent({
-  name: 'Diff',
-
-  props: {
-    src: {
-      type: Object as PropType<Record<string, any>>,
-      required: false,
-    },
-    dst: {
-      type: Object as PropType<Record<string, any>>,
-      required: true,
-    },
-    diff: {
-      type: Object as PropType<Actions>,
-      required: true,
-    },
-    exclude: {
-      type: Array as PropType<Key[]>,
-      default: () => [],
-    },
-    clear: {
-      type: Array as PropType<Key[]>,
-      default: () => [],
-    },
-  },
-
-  computed: {
-    groupedKeys(): string[][] {
-      const keys: string[] = _.sortBy(
-        _.uniq([...Object.keys(this.src || {}), ...Object.keys(this.dst)]),
-        (key) => (this.diff[key] ? -maxActionPriority(this.diff[key]) : 0),
-      )
-
-      return Object.values(
-        _.groupBy(keys, (key) =>
-          this.diff[key]?.map((diff) => `${diff}`)?.join('||')),
-      )
-    },
-  },
-
-  methods: {
-    backgroundClass(key: string): string {
-      return (
-        this.diff[key]
-        && (!this.src || !(key in this.src)
-          ? 'attribute-added'
-          : !(key in this.dst)
-              ? 'attribute-removed'
-              : 'attribute-changed')
-      )
-    },
-
-    actionIcon(key: string): string {
-      return (
-        this.diff[key]
-        && (!this.src || !(key in this.src)
-          ? '➕'
-          : !(key in this.dst)
-              ? '✖'
-              : '~')
-      )
-    },
-
-    showTextDiff(before: string, after: string): boolean {
-      const d = this.diffText(before, after)
-      return d.length <= 2
-    },
-
-    diffText(before: string, after: string): Change[] {
-      return diffChars(before, after)
-    },
-  },
+const props = withDefaults(defineProps<{
+  src?: Record<string, any>
+  dst: Record<string, any>
+  diff: Actions
+  exclude?: Key[]
+  clear?: Key[]
+}>(), {
+  exclude: () => [],
+  clear: () => [],
 })
+
+const groupedKeys = computed((): string[][] => {
+  const keys: string[] = _.sortBy(
+    _.uniq([...Object.keys(props.src || {}), ...Object.keys(props.dst)]),
+    (key) => (props.diff[key] ? -maxActionPriority(props.diff[key]) : 0),
+  )
+
+  return Object.values(
+    _.groupBy(keys, (key) =>
+      props.diff[key]?.map((diff) => `${diff}`)?.join('||')),
+  )
+})
+
+function backgroundClass(key: string): string {
+  return (
+    props.diff[key]
+    && (!props.src || !(key in props.src)
+      ? 'attribute-added'
+      : !(key in props.dst)
+          ? 'attribute-removed'
+          : 'attribute-changed')
+  )
+}
+
+function actionIcon(key: string): string {
+  return (
+    props.diff[key]
+    && (!props.src || !(key in props.src)
+      ? '➕'
+      : !(key in props.dst)
+          ? '✖'
+          : '~')
+  )
+}
+
+function showTextDiff(before: string, after: string): boolean {
+  const d = diffText(before, after)
+  return d.length <= 2
+}
+
+function diffText(before: string, after: string): Change[] {
+  return diffChars(before, after)
+}
 </script>
 
 <template>

--- a/components/DiffMap.vue
+++ b/components/DiffMap.vue
@@ -18,17 +18,11 @@ const props = defineProps<{
   changeGeom?: Geometry[]
 }>()
 
-//
-// Data
-//
 const mapContainerRef = shallowRef<InstanceType<typeof HTMLDivElement>>()
 const noChanges = ref(false)
 const bounds = ref<LngLatBounds>()
 const geometries = ref<Geometry[]>()
 
-//
-// Hooks
-//
 onMounted(() => {
   if (mapContainerRef.value) {
     const map = new Map({

--- a/components/LoChaItem.vue
+++ b/components/LoChaItem.vue
@@ -1,30 +1,18 @@
 <script setup lang="ts">
 import type { LoCha } from '~/libs/types'
 
-//
-// Props
-//
 const props = defineProps<{
   borderColor?: string
   projectSlug: string
   item: LoCha
 }>()
 
-//
-// Emits
-//
 defineEmits<{
   (e: 'accept', id: number): void
 }>()
 
-//
-// Composables
-//
 const user = useUser()
 
-//
-// Computed
-//
 const lochaCount = computed(() => props.item.objects.length)
 
 const isProjectUser = computed(() => !!user.value?.projects?.includes(props.projectSlug))

--- a/components/LoChaList.vue
+++ b/components/LoChaList.vue
@@ -1,35 +1,20 @@
 <script setup lang="ts">
 import type { LoCha } from '~/libs/types'
 
-//
-// Props
-//
 const props = defineProps<{
   projectSlug: string
   loChas: LoCha[]
 }>()
 
-//
-// Emits
-//
 defineEmits<{
   (e: 'accept', id: number): void
 }>()
 
-//
-// Data
-//
 const scrollCount = ref(10)
 const borderColors = ['#363637', '#636466', '#A3A6AD', '#E5EAF3']
 
-//
-// Computed
-//
 const lazyLoChas = computed(() => props.loChas.slice(0, scrollCount.value))
 
-//
-// Methods
-//
 function scrollLoad() {
   scrollCount.value += 10
 }

--- a/components/LogFilters.vue
+++ b/components/LogFilters.vue
@@ -3,33 +3,18 @@ import type { LocationQuery } from 'vue-router'
 import type { Log } from '~/libs/types'
 import { countBy, indexBy, sortBy, uniq } from 'underscore'
 
-//
-// Props
-//
 const props = defineProps<{
   logs: Log[]
 }>()
 
-//
-// Composables
-//
 const route = useRoute()
 
-//
-// Data
-//
 const filters = ref<LocationQuery>()
 
-//
-// Watchers
-//
 watchEffect(() => {
   filters.value = route.query
 })
 
-//
-// Computed
-//
 const stats = computed(() => {
   const actions = props.logs
     .map((log) =>

--- a/components/Object.vue
+++ b/components/Object.vue
@@ -1,28 +1,16 @@
-<script lang="ts">
-import type { PropType } from 'vue'
-
-export default defineNuxtComponent({
-  name: 'DiffCompinent',
-
-  props: {
-    object: {
-      type: Object as PropType<Record<string, any>>,
-      required: true,
-    },
-    exclude: {
-      type: Array as PropType<string[]>,
-      default: () => [],
-    },
-  },
-
-  computed: {
-    keys(): string[] {
-      return Object.keys(this.object).filter(
-        (key) => !this.exclude.includes(key),
-      )
-    },
-  },
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+  object: Record<string, any>
+  exclude?: string[]
+}>(), {
+  exclude: () => [],
 })
+
+const keys = computed(() =>
+  Object.keys(props.object).filter(
+    (key) => !props.exclude.includes(key),
+  ),
+)
 </script>
 
 <template>

--- a/components/UserGroups.vue
+++ b/components/UserGroups.vue
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script setup lang="ts">
 import type { Feature, FeatureCollection, MultiPolygon, Polygon } from 'geojson'
 import type {
   FillLayerSpecification,
@@ -12,104 +12,92 @@ import {
 } from 'maplibre-gl'
 import _ from 'underscore'
 
+const props = defineProps<{
+  userGroups: UserGroup[]
+}>()
+
 const colors = ['#2364AA', '#EA7317', '#73BFB8', '#FEC601', '#3DA5D9']
 
-export default defineNuxtComponent({
-  name: 'UserGroup',
+const mapContainer = useTemplateRef<HTMLDivElement>('mapContainer')
 
-  props: {
-    userGroups: {
-      type: Object as PropType<UserGroup[]>,
-      required: true,
-    },
-  },
-
-  setup() {
-    const mapContainer = shallowRef(null)
-    return { mapContainer }
-  },
-
-  mounted() {
-    const fetchAllPolygons: Promise<
-      Feature<Polygon | MultiPolygon> | undefined
-    >[] = this.userGroups
-      .map((userGroup, index) => {
-        return {
-          ...userGroup,
-          color: colors[index % colors.length],
-        }
-      })
-      .filter((userGroup) => !!userGroup.polygon)
-      .map((userGroup) => {
-        return fetch(userGroup.polygon!).then(async (data) => {
-          if (data.ok) {
-            const geojson: Feature<Polygon | MultiPolygon> = {
-              type: 'Feature',
-              geometry: await data.json(),
-              properties: { color: userGroup.color },
-            }
-            return Promise.resolve(geojson)
+onMounted(() => {
+  const fetchAllPolygons: Promise<
+    Feature<Polygon | MultiPolygon> | undefined
+  >[] = props.userGroups
+    .map((userGroup, index) => {
+      return {
+        ...userGroup,
+        color: colors[index % colors.length],
+      }
+    })
+    .filter((userGroup) => !!userGroup.polygon)
+    .map((userGroup) => {
+      return fetch(userGroup.polygon!).then(async (data) => {
+        if (data.ok) {
+          const geojson: Feature<Polygon | MultiPolygon> = {
+            type: 'Feature',
+            geometry: await data.json(),
+            properties: { color: userGroup.color },
           }
-        })
-      })
-
-    Promise.all(fetchAllPolygons).then((allPolygons) => {
-      const geojson = {
-        type: 'FeatureCollection',
-        features: _.compact(allPolygons),
-      } as FeatureCollection
-      const bounds = new LngLatBounds(
-        bbox(geojson) as [number, number, number, number],
-      )
-
-      const map = new Map({
-        container: this.mapContainer!,
-        style:
-          'https://vecto.teritorio.xyz/styles/teritorio-basic/style.json?key=teritorio_clearance-1-ahNoohaepohy9iexoo3qua',
-        bounds,
-        fitBoundsOptions: { maxZoom: 20, padding: 50 },
-        cooperativeGestures: true,
-        attributionControl: false,
-      })
-
-      map.on('load', () => {
-        map.addSource('geojson', { type: 'geojson', data: geojson })
-
-        map.addLayer({
-          id: 'geojsonFill',
-          type: 'fill',
-          source: 'geojson',
-          filter: ['==', '$type', 'Polygon'],
-          paint: {
-            'fill-color': ['get', 'color'],
-            'fill-opacity': 0.3,
-          },
-        } as FillLayerSpecification)
-        map.addLayer({
-          id: 'geojsonBorder',
-          type: 'line',
-          source: 'geojson',
-          filter: ['==', '$type', 'Polygon'],
-          paint: {
-            'line-color': ['get', 'color'],
-            'line-width': 2,
-          },
-        } as LineLayerSpecification)
+          return Promise.resolve(geojson)
+        }
       })
     })
-  },
 
-  computed: {
-    groups() {
-      return Object.values(this.userGroups).map((userGroup, index) => {
-        return {
-          ...userGroup,
-          color: colors[index % colors.length],
-        }
-      })
-    },
-  },
+  Promise.all(fetchAllPolygons).then((allPolygons) => {
+    const geojson = {
+      type: 'FeatureCollection',
+      features: _.compact(allPolygons),
+    } as FeatureCollection
+    const bounds = new LngLatBounds(
+      bbox(geojson) as [number, number, number, number],
+    )
+
+    const map = new Map({
+      container: mapContainer.value!,
+      style:
+        'https://vecto.teritorio.xyz/styles/teritorio-basic/style.json?key=teritorio_clearance-1-ahNoohaepohy9iexoo3qua',
+      bounds,
+      fitBoundsOptions: { maxZoom: 20, padding: 50 },
+      cooperativeGestures: true,
+      attributionControl: false,
+    })
+
+    map.on('load', () => {
+      map.addSource('geojson', { type: 'geojson', data: geojson })
+
+      map.addLayer({
+        id: 'geojsonFill',
+        type: 'fill',
+        source: 'geojson',
+        filter: ['==', '$type', 'Polygon'],
+        paint: {
+          'fill-color': ['get', 'color'],
+          'fill-opacity': 0.3,
+        },
+      } as FillLayerSpecification)
+      map.addLayer({
+        id: 'geojsonBorder',
+        type: 'line',
+        source: 'geojson',
+        filter: ['==', '$type', 'Polygon'],
+        paint: {
+          'line-color': ['get', 'color'],
+          'line-width': 2,
+        },
+      } as LineLayerSpecification)
+    })
+  })
 })
+
+const groups = computed(() =>
+  Object.values(props.userGroups).map((userGroup, index) => {
+    return {
+      ...userGroup,
+      color: colors[index % colors.length],
+    }
+  }),
+)
 </script>
 
 <template>

--- a/components/UserProfile.vue
+++ b/components/UserProfile.vue
@@ -1,39 +1,26 @@
-<script lang="ts">
-import type { PropType } from 'vue'
+<script setup lang="ts">
 import type { User } from '~/libs/types'
 import { userLogout } from '~/libs/apiTypes'
 
-export default defineNuxtComponent({
-  name: 'User',
-
-  props: {
-    user: {
-      type: Object as PropType<User | null>,
-      default: null,
-    },
-  },
-
-  setup() {
-    const form = shallowRef<HTMLFormElement>()
-
-    return { form }
-  },
-
-  computed: {
-    loginUrl(): string {
-      return `${this.$config.public.api}../../../users/auth/osm_oauth2`
-    },
-  },
-
-  methods: {
-    submit(): void {
-      this.form?.submit()
-    },
-    logout(): void {
-      userLogout(this.$config.public.api)
-    },
-  },
+withDefaults(defineProps<{
+  user?: User | null
+}>(), {
+  user: null,
 })
+
+const form = useTemplateRef<HTMLFormElement>('form')
+
+const { public: { api } } = useRuntimeConfig()
+
+const loginUrl = computed(() => `${api}../../../users/auth/osm_oauth2`)
+
+function submit(): void {
+  form.value?.submit()
+}
+
+function logout(): void {
+  userLogout(api)
+}
 </script>
 
 <template>

--- a/pages/[project]/changes_logs.vue
+++ b/pages/[project]/changes_logs.vue
@@ -2,18 +2,12 @@
 import type { Geometry } from 'geojson'
 import { uniq } from 'underscore'
 
-//
-// Validators
-//
 definePageMeta({
   validate({ params }) {
     return /^[-\w:]+$/.test(params.project as string)
   },
 })
 
-//
-// Composables
-//
 const router = useRouter()
 const route = useRoute()
 const projectSlug = route.params.project.toString()
@@ -21,9 +15,6 @@ const config = useRuntimeConfig()
 const user = useUser()
 const { data, status, refresh } = useChangesLogs(projectSlug)
 
-//
-// Computed
-//
 const baseGeoms = computed(() => {
   if (!data.value?.logs) {
     return []
@@ -99,9 +90,6 @@ useHead({
   ],
 })
 
-//
-// Methods
-//
 async function handleAccept(loChaIds?: number[]) {
   try {
     if (!loChaIds) {


### PR DESCRIPTION
## Summary
- Convert 5 components from `defineNuxtComponent`/Options API to `<script setup>` Composition API: `Object.vue`, `Changesets.vue`, `UserProfile.vue`, `Diff.vue`, `UserGroups.vue`
- Remove `// SectionName //` comment blocks from 5 existing `<script setup>` components: `LogFilters.vue`, `DiffMap.vue`, `LoChaItem.vue`, `LoChaList.vue`, `changes_logs.vue`

Prerequisite for #295 (Nuxt 3 → 4 upgrade).

Closes #318

## Test plan
- [x] `yarn lint` passes
- [x] `yarn nuxi typecheck .` passes
- [ ] Dev server starts without errors (`yarn dev`)
- [ ] Pages using these components render correctly