### PR TITLE
fix: disable i18n nitroContextDetection for SPA mode

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,6 +54,10 @@ export default defineNuxtConfig({
 
   i18n: {
     strategy: 'no_prefix',
+    experimental: {
+      // Disable server redirect detection — incompatible with ssr: false
+      nitroContextDetection: false,
+    },
     detectBrowserLanguage: {
       useCookie: false,
     },


### PR DESCRIPTION
## Summary

- Fix runtime error: `Nuxt I18n server context has not been set up yet`
- The `@nuxtjs/i18n` v10 `nitroContextDetection` experimental feature is incompatible with `ssr: false` — the server `render:before` hook tries to access an i18n context that isn't initialized in SPA mode
- Disable `nitroContextDetection` in the i18n config

## Test plan

- [x] `yarn lint` passes
- [x] `yarn nuxi typecheck .` passes
- [ ] `yarn dev` starts without the server context error
- [ ] Locale switching still works

Ref #295, #321