### PR TITLE
chore: nuxt 4 quick prep fixes (items 2, 5, 9 from #295)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,7 +17,7 @@ export default defineNuxtConfig({
       meta: [
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-        { hid: 'description', name: 'description', content: '' },
+        { name: 'description', content: '' },
         { name: 'format-detection', content: 'telephone=no' },
       ],
       link: [{ rel: 'icon', href: '/favicon.ico' }],
@@ -40,7 +40,7 @@ export default defineNuxtConfig({
     transpile: [/lodash.*/],
   },
 
-  compatibilityDate: '2024-07-16',
+  compatibilityDate: '2025-01-01',
 
   typescript: {
     typeCheck: 'build',


### PR DESCRIPTION
## Summary

- Remove deprecated `hid` from meta tags — Unhead v2 (bundled in Nuxt 4) auto-deduplicates by tag key
- Bump `compatibilityDate` from `2024-07-16` to `2025-01-01`
- Item 9 (`statusCode`/`statusMessage` deprecations): audited all usage, no deprecated patterns found — no changes needed

## Test plan

- [x] `yarn lint` passes
- [x] `yarn nuxi typecheck .` passes
- [ ] `yarn dev` starts without errors

Closes #324
Ref #295 (items 2, 5, 9)