### PR TITLE
Audit and fix data fetching for Nuxt 4 compatibility

### DIFF
--- a/composables/useChangesLogs.ts
+++ b/composables/useChangesLogs.ts
@@ -42,11 +42,11 @@ export function useChangesLogs(projectSlug: string) {
       }
     },
     {
-      getCachedData(key) {
+      getCachedData(key): ChangesLogsData | undefined {
         const data = nuxtApp.payload.data[key] || nuxtApp.static.data[key]
 
         if (!data) {
-          return null
+          return undefined
         }
 
         // Check if the cached data has expired
@@ -55,7 +55,7 @@ export function useChangesLogs(projectSlug: string) {
         const isExpired = expirationDate.getTime() < Date.now()
 
         if (isExpired) {
-          return null
+          return undefined
         }
 
         return data

--- a/libs/getAsyncData.ts
+++ b/libs/getAsyncData.ts
@@ -19,7 +19,7 @@ export function getAsyncDataOrThrows<
   options?: AsyncDataOptions<DataT, Transform, PickKeys>,
 ): AsyncData<DataT, DataE> {
   return useAsyncData(key, handler, options).then((asyncData) => {
-    if (asyncData.error != null && asyncData.error.value) {
+    if (asyncData.error.value) {
       throw asyncData.error
     }
     else {
@@ -39,7 +39,7 @@ export function getAsyncDataOrNull<
   options?: AsyncDataOptions<DataT, Transform, PickKeys>,
 ): AsyncData<DataT, DataE> {
   return useAsyncData(key, handler, options).then((asyncData) => {
-    if (asyncData.error != null && asyncData.error.value) {
+    if (asyncData.error.value) {
       return undefined
     }
     else {


### PR DESCRIPTION
## Summary

- `getCachedData` in `useChangesLogs.ts` now returns `undefined` instead of `null` to correctly signal cache misses in Nuxt 4
- Simplified redundant `asyncData.error != null &&` checks in `getAsyncData.ts` — `asyncData.error` is always a Ref, never null/undefined

All changes are backward-compatible with Nuxt 3.

## Audit results (no changes needed)

| Pattern | Location | Status |
|---------|----------|--------|
| `!cached.value` | `useFetchWithCache.ts:4` | OK — falsy check covers both null and undefined |
| `if (error.value)` | `useFetchWithCache.ts:7` | OK — truthy check works for both |
| `cached.value = data.value` | `useFetchWithCache.ts:15` | OK — full reassignment, not deep mutation |
| `status === 'pending'/'idle'/'success'` | `changes_logs.vue` | OK — same string values in Nuxt 4 |
| `data?.data.value` truthy check | `getAsyncData.ts:53` | OK — covers null and undefined |
| `refresh({ dedupe: ... })` | nowhere | Not used in codebase |
| Deep mutations on data refs | nowhere | Not found |

## Test plan

- [ ] `yarn lint` passes
- [ ] `yarn nuxi typecheck .` passes
- [ ] `yarn dev` — navigate to a project's changes_logs page, confirm data loads

Closes #326