### PR TITLE
chore: bump TypeScript from 5.6.3 to 5.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "nuxt": "^4.4.2",
     "postcss-html": "^1.8.1",
     "simple-git-hooks": "^2.13.1",
-    "typescript": "5.6.3",
+    "typescript": "5.8.3",
     "vue-tsc": "^3.2.6"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14204,23 +14204,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.6.3":
-  version: 5.6.3
-  resolution: "typescript@npm:5.6.3"
+"typescript@npm:5.8.3":
+  version: 5.8.3
+  resolution: "typescript@npm:5.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
+  checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>":
-  version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
+"typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
+  version: 5.8.3
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/7c9d2e07c81226d60435939618c91ec2ff0b75fbfa106eec3430f0fcf93a584bc6c73176676f532d78c3594fe28a54b36eb40b3d75593071a7ec91301533ace7
+  checksum: 10c0/92ea03509e06598948559ddcdd8a4ae5a7ab475766d5589f1b796f5731b3d631a4c7ddfb86a3bd44d58d10102b132cd4b4994dda9b63e6273c66d77d6a271dbd
   languageName: node
   linkType: hard
 
@@ -15072,7 +15072,7 @@ __metadata:
     nuxt: "npm:^4.4.2"
     postcss-html: "npm:^1.8.1"
     simple-git-hooks: "npm:^2.13.1"
-    typescript: "npm:5.6.3"
+    typescript: "npm:5.8.3"
     underscore: "npm:^1.13.6"
     v-lazy-component: "npm:^3.0.9"
     vue: "npm:^3.5.13"


### PR DESCRIPTION
## Summary
- Bumps `typescript` from `5.6.3` to `5.8.3` (latest stable 5.x)
- Regenerates `yarn.lock`

## Test plan
- [x] `yarn nuxi typecheck .` passes
- [x] `yarn lint` passes
- [x] `yarn dev` boots without errors

Closes #335