### PR TITLE
fix: handle null lastUpdate prop in ProjectStats

### DIFF
--- a/app/components/ProjectStats.vue
+++ b/app/components/ProjectStats.vue
@@ -7,7 +7,7 @@ import localizedFormat from 'dayjs/plugin/localizedFormat'
 import relativeTime from 'dayjs/plugin/relativeTime'
 
 const props = defineProps<{
-  lastUpdate?: string
+  lastUpdate?: string | null
   toBeValidated?: number
 }>()
 
@@ -19,6 +19,9 @@ const _daysjsLocale = { en, fr, es }
 
 const { locale } = useI18n()
 const lastUpdateFormatted = computed(() => {
+  if (!props.lastUpdate) {
+    return null
+  }
   return dayjs(props.lastUpdate)
     .locale(locale.value)
     .fromNow()
@@ -27,9 +30,9 @@ const lastUpdateFormatted = computed(() => {
 
 <template>
   <el-row>
-    <el-col :span="12">
+    <el-col v-if="lastUpdateFormatted" :span="12">
       <label>{{ $t('project.lastUpdate') }}</label>
-      <time :datetime="lastUpdate">{{ lastUpdateFormatted }}</time>
+      <time :datetime="lastUpdate ?? undefined">{{ lastUpdateFormatted }}</time>
     </el-col>
     <el-col v-if="toBeValidated !== undefined" :span="12">
       <label>{{ $t('project.toBeValidated') }}</label>

--- a/app/libs/types.ts
+++ b/app/libs/types.ts
@@ -151,7 +151,7 @@ export interface Project {
   id: string
   title: MultilingualString
   description: MultilingualString
-  date_last_update?: string
+  date_last_update?: string | null
   to_be_validated?: number
   main_contacts: string[]
   user_groups: UserGroup[]


### PR DESCRIPTION
## Summary
- Accept `null` for the `lastUpdate` prop and `date_last_update` type to match the API response
- Guard the computed and template to avoid Vue runtime prop type warnings and invalid dayjs output
- Hide the "Data freshness" column when no date is available

## Test plan
- [x] `yarn nuxi typecheck .` passes
- [x] `yarn lint` passes

Closes #280