### PR TITLE
fix: add fallback to first available language in useI18nHash

### DIFF
--- a/app/composables/useI18nHash.ts
+++ b/app/composables/useI18nHash.ts
@@ -3,5 +3,14 @@ import type { MultilingualString } from '~/libs/types'
 export function useI18nHash(messages: MultilingualString): string | undefined {
   const { locale } = useI18n()
 
-  return (messages != null && (messages[locale.value] || messages.en)) || undefined
+  if (messages == null) {
+    return undefined
+  }
+
+  return (
+    messages[locale.value]
+    || messages.en
+    || Object.values(messages).find((v) => !!v)
+    || undefined
+  )
 }


### PR DESCRIPTION
## Summary
- When the current locale and English are both missing from a multilingual string, fall back to the first available language instead of returning `undefined`
- Fixes user_group titles showing blank when the API only returns non-English translations

## Test plan
- [x] `yarn nuxi typecheck .` passes
- [x] `yarn lint` passes

Closes #279