### PR TITLE
fix: hide tilde indicator when attribute values are unchanged

### DIFF
--- a/app/components/Diff.vue
+++ b/app/components/Diff.vue
@@ -38,6 +38,9 @@ function backgroundClass(key: string): string {
   if (!(key in props.dst)) {
     return 'attribute-removed'
   }
+  if (props.src[key] === props.dst[key]) {
+    return ''
+  }
   return 'attribute-changed'
 }
 
@@ -50,6 +53,9 @@ function actionIcon(key: string): string {
   }
   if (!(key in props.dst)) {
     return '✖'
+  }
+  if (props.src[key] === props.dst[key]) {
+    return ''
   }
   return '~'
 }


### PR DESCRIPTION
## Summary
- Compare actual `src` and `dst` values before showing the `~` modification indicator and `attribute-changed` background
- The diff backend may include keys in `diff_attribs` even when values are identical

## Test plan
- [x] `yarn nuxi typecheck .` passes
- [x] `yarn lint` passes

Closes #252