### PR TITLE
chore: replace v-lazy-component with Nuxt built-in lazy loading

### DIFF
--- a/app/components/LogItem.vue
+++ b/app/components/LogItem.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { Log, Match, ObjType } from '~/libs/types'
 import { compact, uniq } from 'underscore'
-import LazyComponent from 'v-lazy-component'
 import { objTypeFull } from '~/libs/types'
 
 const props = defineProps<{
@@ -148,16 +147,16 @@ function uniqHistoryIds(log: Log) {
           ]"
           :clear="['members', 'geom']"
         />
-        <LazyComponent
+        <div
           v-if="log.base?.geom || log.change.geom"
           style="border: 1px solid lightgrey"
         >
-          <diff-map
+          <lazy-diff-map
             v-if="log.base || !log.change.deleted"
             :base-geom="log.base ? [log.base.geom].filter(Boolean) : undefined"
             :change-geom="!log.change.deleted ? [log.change.geom] : undefined"
           />
-        </LazyComponent>
+        </div>
       </el-col>
       <el-col :span="10">
         <diff

--- a/app/declarations.d.ts
+++ b/app/declarations.d.ts
@@ -1,1 +1,0 @@
-declare module 'v-lazy-component'

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "element-plus": "^2.13.6",
     "maplibre-gl": "^4.1.2",
     "underscore": "^1.13.6",
-    "v-lazy-component": "^3.0.9",
     "vue": "^3.5.13"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14674,13 +14674,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"v-lazy-component@npm:^3.0.9":
-  version: 3.0.9
-  resolution: "v-lazy-component@npm:3.0.9"
-  checksum: 10c0/352c9235959b1e172f20ca74fc98189fe203ef9319fd0e4c0ba0e4fd7e6de3e72a5250f16057f1aef7ebb3e9db7b8cc577bc1a21d5fe6fd516c34a7659aa7683
-  languageName: node
-  linkType: hard
-
 "v8-to-istanbul@npm:^9.0.1":
   version: 9.3.0
   resolution: "v8-to-istanbul@npm:9.3.0"
@@ -15074,7 +15067,6 @@ __metadata:
     simple-git-hooks: "npm:^2.13.1"
     typescript: "npm:5.8.3"
     underscore: "npm:^1.13.6"
-    v-lazy-component: "npm:^3.0.9"
     vue: "npm:^3.5.13"
     vue-tsc: "npm:^3.2.6"
   languageName: unknown


### PR DESCRIPTION
## Summary
- Replace the abandoned `v-lazy-component` package with Nuxt's built-in `<lazy-diff-map>` prefix
- Remove `v-lazy-component` from dependencies and its type declaration

## Test plan
- [x] `yarn nuxi typecheck .` passes
- [x] `yarn lint` passes

Closes #307