### PR TITLE
fix: always navigate to changes_logs from project detail button

### DIFF
--- a/app/components/ProjectLight.vue
+++ b/app/components/ProjectLight.vue
@@ -6,18 +6,11 @@ const props = defineProps<{
   titleTag: HTMLTags
 }>()
 
-const route = useRoute()
 const { t } = useI18n()
-const details = computed(() => {
-  let label = t('project.details')
-  let url = `/${props.project.id}`
-
-  if (route.name === 'index') {
-    label = t('project.control')
-    url += '/changes_logs'
-  }
-  return { label, url }
-})
+const details = computed(() => ({
+  label: t('project.details'),
+  url: `/${props.project.id}/changes_logs`,
+}))
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- The detail button previously went to the project overview page when not on the index
- Now it consistently navigates to the changes_logs page
- Simplified the computed property and removed unused `useRoute()` import

## Test plan
- [x] `yarn nuxi typecheck .` passes
- [x] `yarn lint` passes

Closes #288