### PR TITLE
feat: display empty state messages in changes logs

### DIFF
--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -151,7 +151,7 @@ function matchFilterBySelectors(selectors: string[]) {
   <el-main
     v-loading.lock="status === 'pending'"
     element-loading-background="#FAFAFA"
-    element-loading-text="Loading..."
+    :element-loading-text="$t('common.loading')"
   >
     <el-alert v-if="status === 'idle' && !data" :title="$t('logs.no_data')" type="warning" />
     <el-container v-if="data && status === 'success'" direction="vertical">
@@ -175,14 +175,18 @@ function matchFilterBySelectors(selectors: string[]) {
         <li>{{ $t('logs.data_details_manual') }}</li>
       </ul>
       <lo-cha-list
-        v-if="data.loChas.length"
+        v-if="loChasWithFilter.length"
         :project-slug="projectSlug"
         :lo-chas="loChasWithFilter"
         @accept="handleAccept([$event])"
       />
       <el-empty
-        v-if="data.loChas.length && !loChasWithFilter.length"
+        v-else-if="data.loChas.length"
         :description="$t('logs.no_results')"
+      />
+      <el-empty
+        v-else
+        :description="$t('logs.no_data')"
       />
     </el-container>
   </el-main>

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -153,7 +153,7 @@ function matchFilterBySelectors(selectors: string[]) {
     element-loading-background="#FAFAFA"
     element-loading-text="Loading..."
   >
-    <el-alert v-if="status === 'idle' && !data" title="No data available at the moment." type="warning" />
+    <el-alert v-if="status === 'idle' && !data" :title="$t('logs.no_data')" type="warning" />
     <el-container v-if="data && status === 'success'" direction="vertical">
       <project-light :project="data.project" title-tag="h1" />
       <el-row>
@@ -179,6 +179,10 @@ function matchFilterBySelectors(selectors: string[]) {
         :project-slug="projectSlug"
         :lo-chas="loChasWithFilter"
         @accept="handleAccept([$event])"
+      />
+      <el-empty
+        v-if="data.loChas.length && !loChasWithFilter.length"
+        :description="$t('logs.no_results')"
       />
     </el-container>
   </el-main>

--- a/i18n/locales/en.js
+++ b/i18n/locales/en.js
@@ -37,6 +37,8 @@ export default {
       'If after review it is ok, use the ✓ check to integrate the changes.',
     tags_more: '(and more)',
     validate_selection: 'Validate all filtered',
+    no_data: 'No data available at the moment.',
+    no_results: 'No results match the current filters.',
   },
   project: {
     control: 'Control',

--- a/i18n/locales/en.js
+++ b/i18n/locales/en.js
@@ -1,4 +1,7 @@
 export default {
+  common: {
+    loading: 'Loading...',
+  },
   app: {
     title: 'Clearance for OSM Data',
     summary:

--- a/i18n/locales/es.js
+++ b/i18n/locales/es.js
@@ -1,4 +1,7 @@
 export default {
+  common: {
+    loading: 'Cargando...',
+  },
   app: {
     title: '"Clearance" para datos OSM',
     summary:

--- a/i18n/locales/es.js
+++ b/i18n/locales/es.js
@@ -37,6 +37,8 @@ export default {
       'Si después de la comprobación es correcto, utiliza ✓ para integrar los cambios.',
     tags_more: '(y mas)',
     validate_selection: 'Validar objetos filtrados',
+    no_data: 'No hay datos disponibles en este momento.',
+    no_results: 'Ningún resultado coincide con los filtros actuales.',
   },
   project: {
     control: 'Control',

--- a/i18n/locales/fr.js
+++ b/i18n/locales/fr.js
@@ -37,6 +37,8 @@ export default {
       'Si, après examen, tout est bon, utilisez le contrôle ✓ pour intégrer les modifications.',
     tags_more: '(et plus)',
     validate_selection: 'Valider les objets filtrés',
+    no_data: 'Aucune donnée disponible pour le moment.',
+    no_results: 'Aucun résultat ne correspond aux filtres actuels.',
   },
   project: {
     control: 'Contrôle',

--- a/i18n/locales/fr.js
+++ b/i18n/locales/fr.js
@@ -1,4 +1,7 @@
 export default {
+  common: {
+    loading: 'Chargement...',
+  },
   app: {
     title: '"Clearance" pour les données OSM',
     summary:


### PR DESCRIPTION
## Summary
- Add i18n keys for empty data (`logs.no_data`) and no filter results (`logs.no_results`) in en/fr/es
- Replace hardcoded English string with i18n key
- Show `<el-empty>` when filters return zero results

## Test plan
- [x] `yarn nuxi typecheck .` passes
- [x] `yarn lint` passes

Closes #232