### PR TITLE
chore: upgrade TypeScript from 5 to 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "nuxt": "^4.4.2",
     "postcss-html": "^1.8.1",
     "simple-git-hooks": "^2.13.1",
-    "typescript": "5.8.3",
+    "typescript": "^6.0.2",
     "vitest": "^3.1.1",
     "vue-tsc": "^3.2.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12562,23 +12562,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.8.3":
-  version: 5.8.3
-  resolution: "typescript@npm:5.8.3"
+"typescript@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "typescript@npm:6.0.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
+  checksum: 10c0/4b860b0bf87cc0fee0f66d8ef2640b5a8a8a8c74d1129adb82e389e5f97124383823c47946bef8a73ede371461143a3aa8544399d2133c7b2e4f07e81860af7f
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
-  version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=8c6c40"
+"typescript@patch:typescript@npm%3A^6.0.2#optional!builtin<compat/typescript>":
+  version: 6.0.2
+  resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/92ea03509e06598948559ddcdd8a4ae5a7ab475766d5589f1b796f5731b3d631a4c7ddfb86a3bd44d58d10102b132cd4b4994dda9b63e6273c66d77d6a271dbd
+  checksum: 10c0/4c3eccf92033332f7ec412d762d5049de77b76d78faa26468bc3ad869b3e53d0e70540bf32653e4380adf537f1d716ac0fa50839864bf9e5ee406843a2c936a4
   languageName: node
   linkType: hard
 
@@ -13445,7 +13445,7 @@ __metadata:
     nuxt: "npm:^4.4.2"
     postcss-html: "npm:^1.8.1"
     simple-git-hooks: "npm:^2.13.1"
-    typescript: "npm:5.8.3"
+    typescript: "npm:^6.0.2"
     underscore: "npm:^1.13.6"
     vitest: "npm:^3.1.1"
     vue: "npm:^3.5.13"


### PR DESCRIPTION
## Summary
- Upgrades `typescript` from 5.8.3 to ^6.0.2
- No code changes required — Nuxt-generated tsconfig was already TS6-compatible

## Verification
- `nuxi typecheck` passes
- `yarn lint` passes
- `yarn build` succeeds

Closes #301