### PR TITLE
feat: support new ProjectsResponse API format with admin field

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Project, User } from '~/libs/types'
+import type { Project, ProjectsResponse, User } from '~/libs/types'
 
 const config = useRuntimeConfig()
 
@@ -14,8 +14,9 @@ await callOnce(async () => {
 })
 
 try {
-  const projects = await useFetchWithCache<Project[]>('projects', `${config.public.api}/projects`)
-  useState<Project[]>('projects', () => projects.value)
+  const response = await useFetchWithCache<ProjectsResponse>('projectsResponse', `${config.public.api}/projects`)
+  useState<string | null>('admin', () => response.value?.admin ?? null)
+  useState<Project[]>('projects', () => response.value?.projects ?? [])
 }
 catch (err: any) {
   ElMessage.error({

--- a/app/composables/state.ts
+++ b/app/composables/state.ts
@@ -4,6 +4,8 @@ export const useLoChas = () => useState<LoCha[]>('loChas')
 
 export const useLogs = () => useState<Log[]>('logs')
 
+export const useAdmin = () => useState<string | null>('admin', () => null)
+
 export const useProjects = () => useState<Project[]>('projects')
 
 export const useUser = () => useState<User | null>('user', () => null)

--- a/app/libs/types.ts
+++ b/app/libs/types.ts
@@ -158,10 +158,15 @@ export interface Project {
   project_tags: string[]
 }
 
-export function getProjects(apiEndpoint: string): Promise<Project[]> {
+export interface ProjectsResponse {
+  admin?: string
+  projects: Project[]
+}
+
+export function getProjects(apiEndpoint: string): Promise<ProjectsResponse> {
   return fetch(`${apiEndpoint}/projects`).then((data) => {
     if (data.ok) {
-      return data.json() as unknown as Project[]
+      return data.json() as unknown as ProjectsResponse
     }
     else {
       return Promise.reject(

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -32,7 +32,7 @@ otherProjects.value = other
           <p v-if="admin">
             {{ $t('app.project.new') }}
             <a
-              :href="`https://www.openstreetmap.org/user/${admin}`"
+              :href="`https://www.openstreetmap.org/user/${encodeURIComponent(admin)}`"
               target="_blank"
             >{{ admin }}</a>
           </p>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,6 +2,7 @@
 import type { Project } from '~/libs/types'
 import _ from 'underscore'
 
+const admin = useAdmin()
 const user = useUser()
 const projects = useProjects()
 const myProjects = ref<Project[]>()
@@ -28,12 +29,12 @@ otherProjects.value = other
               $t('app.github')
             }}</a>
           </p>
-          <p>
+          <p v-if="admin">
             {{ $t('app.project.new') }}
             <a
-              href="https://www.openstreetmap.org/user/frodrigo"
+              :href="`https://www.openstreetmap.org/user/${admin}`"
               target="_blank"
-            >frodrigo</a>
+            >{{ admin }}</a>
           </p>
         </el-col>
         <el-col :span="6">


### PR DESCRIPTION
## Summary
- Add `ProjectsResponse` interface wrapping `{ admin?, projects[] }` to match new API format
- Add `useAdmin()` composable to store the admin username
- Conditionally display admin contact link with dynamic OSM username

Closes #350

## Test plan
- [ ] Verify `/projects` API response is correctly parsed
- [ ] Verify admin link appears when `admin` field is present
- [ ] Verify admin link is hidden when `admin` field is absent
- [ ] Verify existing project listing still works correctly