### PR TITLE
fix: show tag diff on before features

### DIFF
--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -1,170 +1,147 @@
 <script setup lang="ts">
-import type { Action, Actions } from '@teritorio/openstreetmap-logical-history-component'
+import type { Actions, IFeature } from '@teritorio/openstreetmap-logical-history-component'
 import type { Change } from 'diff'
 import { diffChars } from 'diff'
 import { groupBy, sortBy, uniq } from 'underscore'
 
 const props = defineProps<{
-  srcTags?: Record<string, string>
-  dstTags?: Record<string, string>
-  diff: Actions
+  diff?: Actions
+  dst?: IFeature['properties']
+  src?: IFeature['properties']
 }>()
 
-function action2priority(logAction: string | null): number {
-  if (!logAction) {
-    return 1
+const loChaColors = {
+  new: '#52c41a',
+  delete: '#FF0000',
+  updateBefore: '#FFA479',
+  updateAfter: '#F2BE00',
+}
+
+const groupedTagKeys = computed((): string[][] => {
+  if (props.src && !props.dst) {
+    return [Object.keys(props.src.tags)]
   }
-  return { reject: 2, accept: 0 }[logAction] ?? 1
-}
 
-function maxActionPriority(actions: Action[]): number {
-  return Math.max(...actions.map((action) => action2priority(action[1])))
-}
-
-const groupedKeys = computed((): [string, ...string[]][] => {
   const keys: string[] = sortBy(
-    uniq([...Object.keys(props.srcTags || {}), ...Object.keys(props.dstTags || {})]),
-    (key) => (props.diff[key] ? -maxActionPriority(props.diff[key] as Action[]) : 0),
+    uniq([
+      ...Object.keys(props.src?.tags || {}),
+      ...Object.keys(props.dst?.tags || {}),
+    ]),
+    (key: string) => {
+      return props.diff?.[key]
+        && (
+          !props.src?.tags || !(key in props.src.tags)
+            ? 0
+            : props.dst && !props.dst.tags[key]
+              ? 2
+              : 1)
+    },
   )
 
   return Object.values(
-    groupBy(keys, (key) =>
-      (props.diff[key] as Action[] | undefined)?.map((d: Action) => `${d}`)?.join('||') ?? ''),
-  ) as [string, ...string[]][]
+    groupBy(
+      keys,
+      (key) => props.diff?.[key]?.map((diff) => `${diff}`).join('||') || '',
+    ),
+  )
 })
 
-function backgroundClass(key: string): string {
-  if (!props.diff[key]) {
-    return ''
+function actionIcon(key: string): string | undefined {
+  if (props.src && !props.dst) {
+    return undefined
   }
-  if (!props.srcTags || !(key in props.srcTags)) {
-    return 'attribute-added'
-  }
-  if (!props.dstTags || !(key in props.dstTags)) {
-    return 'attribute-removed'
-  }
-  if (props.srcTags[key] === props.dstTags[key]) {
-    return ''
-  }
-  return 'attribute-changed'
-}
 
-function actionIcon(key: string): string {
-  if (!props.diff[key]) {
-    return ''
+  if (!props.diff?.[key]) {
+    return undefined
   }
-  if (!props.srcTags || !(key in props.srcTags)) {
+
+  if (!props.src?.tags || !(key in props.src.tags)) {
     return '➕'
   }
-  if (!props.dstTags || !(key in props.dstTags)) {
+
+  if (props.dst && !props.dst.tags[key]) {
     return '✖'
   }
-  if (props.srcTags[key] === props.dstTags[key]) {
-    return ''
-  }
+
   return '~'
 }
 
-function isRejectGroup(groupedKey: [string, ...string[]]): boolean {
-  const actions = props.diff[groupedKey[0]] as Action[] | undefined
-  return actions?.[0]?.[1] === 'reject'
+function backgroundClass(key: string): string | undefined {
+  if (props.src && !props.dst) {
+    return undefined
+  }
+
+  if (!props.diff?.[key]) {
+    return undefined
+  }
+
+  if (!props.src?.tags || !(key in props.src.tags)) {
+    return 'attribute-new'
+  }
+
+  if (props.dst && !props.dst.tags[key]) {
+    return 'attribute-deleted'
+  }
+
+  return 'attribute-changed'
 }
 
-function computeDiff(before: string, after: string): { parts: Change[], isInline: boolean } {
-  const parts = diffChars(before, after)
-  return { parts, isInline: parts.length <= 2 }
+function isRejected(key: string): boolean {
+  const actions = props.diff?.[key]
+  if (!actions || !actions[0]) {
+    return false
+  }
+  return actions[0][1] === 'reject'
+}
+
+function getRowClass(key: string): string | undefined {
+  if (props.src && !props.dst) {
+    return 'no_changes'
+  }
+  return isRejected(key) ? undefined : 'no_changes'
+}
+
+function showTextDiff(before: string, after: string): boolean {
+  return diffText(before, after).length <= 2
+}
+
+function diffText(before: string, after: string): Change[] {
+  return diffChars(before, after)
 }
 </script>
 
 <template>
-  <table>
-    <template v-for="(groupedKey, groupIndex) in groupedKeys" :key="groupedKey">
-      <tr>
-        <th colspan="4">
-          <template v-if="diff[groupedKey[0]] !== undefined">
-            <el-tag
-              v-if="(diff[groupedKey[0]] as Action[])?.length === 0"
-              type="warning"
-              size="small"
-              :disable-transitions="true"
-              class="item"
-            >
-              ?
-            </el-tag>
-
-            <template
-              v-for="(action, actionIndex) in (diff[groupedKey[0]] as Action[])"
-              v-else
-              :key="actionIndex"
-            >
-              <el-dropdown :show-timeout="0">
-                <span class="el-dropdown-link">
-                  <el-badge
-                    :value="
-                      (action && action[2] && Object.keys(action[2]).length)
-                        || undefined
+  <div class="locha-diff">
+    <template
+      v-for="(groupedKey, groupIndex) in groupedTagKeys"
+      :key="groupIndex"
+    >
+      <table v-if="groupedTagKeys.length">
+        <tbody>
+          <template v-for="key in groupedKey" :key="key">
+            <tr :class="getRowClass(key)">
+              <td class="key" :class="[backgroundClass(key)]">
+                {{ actionIcon(key) }}
+              </td>
+              <td
+                :class="isRejected(key) && [backgroundClass(key), 'key']"
+              >
+                {{ key }}
+              </td>
+              <td
+                :class="isRejected(key) && [backgroundClass(key), 'value']"
+              >
+                <template v-if="diff?.[key]">
+                  <span v-if="!src?.tags || !(key in src.tags)">{{ dst?.tags?.[key] }} </span>
+                  <span v-else-if="!(key in (dst?.tags || {}))">{{ src.tags[key] }} </span>
+                  <span
+                    v-else-if="typeof src.tags[key] === 'string'
+                      && showTextDiff(src.tags[key], dst?.tags?.[key] || '')
                     "
-                    class="item"
-                    :type="action[1] === 'reject' ? 'danger' : 'info'"
+                    class="attribute-changed"
                   >
-                    <el-tag
-                      :type="action[1] === 'reject' ? 'danger' : 'info'"
-                      size="small"
-                      :disable-transitions="true"
-                    >
-                      {{ action[0] }}
-                      <template v-if="action && action[2]">⮟</template>
-                    </el-tag>
-                  </el-badge>
-                </span>
-                <template v-if="action && action[2]" #dropdown>
-                  <el-dropdown-menu v-for="(option, i) in action[2]" :key="i">
-                    <el-dropdown-item class="clearfix">
-                      {{ i }}
-                      <template v-if="Array.isArray(option)">
-                        <ul>
-                          <li v-for="op in option" :key="op">
-                            {{ op }}
-                          </li>
-                        </ul>
-                      </template>
-                      <template v-else>
-                        {{ option }}
-                      </template>
-                    </el-dropdown-item>
-                  </el-dropdown-menu>
-                </template>
-              </el-dropdown>
-            </template>
-          </template>
-          <template v-else-if="groupIndex !== 0">
-&nbsp;
-          </template>
-        </th>
-      </tr>
-      <template v-for="key in groupedKey" :key="key">
-        <tr
-          :class="!isRejectGroup(groupedKey) && 'no_changes'"
-        >
-          <td class="key" :class="[backgroundClass(key)]">
-            {{ actionIcon(key) }}
-          </td>
-          <td
-            :class="isRejectGroup(groupedKey) && [backgroundClass(key), 'key']"
-          >
-            {{ key }}
-          </td>
-          <td
-            :class="isRejectGroup(groupedKey) && [backgroundClass(key), 'value']"
-          >
-            <template v-if="diff[key]">
-              <span v-if="!srcTags || !(key in srcTags)">{{ dstTags?.[key] }}</span>
-              <span v-else-if="!dstTags || !(key in dstTags)">{{ srcTags[key] }}</span>
-              <template v-else-if="typeof srcTags[key] === 'string'">
-                <template v-for="(result, ri) in [computeDiff(srcTags[key]!, dstTags![key]!)]" :key="ri">
-                  <span v-if="result.isInline" class="attribute-changed">
                     <span
-                      v-for="(part, i) in result.parts"
+                      v-for="(part, i) in diffText(src.tags[key], dst?.tags?.[key] || '')"
                       :key="i"
                     >
                       <span
@@ -179,56 +156,72 @@ function computeDiff(before: string, after: string): { parts: Change[], isInline
                     </span>
                   </span>
                   <span v-else>
-                    <span class="diff-text-removed">{{ srcTags[key] }}</span>
+                    <span class="diff-text-removed">{{ src.tags[key] }}</span>
                     <br />
-                    <span class="diff-text-added">{{ dstTags?.[key] }}</span>
+                    <span class="diff-text-added">{{ dst?.tags?.[key] }}</span>
                   </span>
                 </template>
-              </template>
-              <span v-else>
-                <span class="diff-text-removed">{{ srcTags[key] }}</span>
-                <br />
-                <span class="diff-text-added">{{ dstTags?.[key] }}</span>
-              </span>
-            </template>
-            <template v-else>
-              {{ dstTags?.[key] ?? srcTags?.[key] }}
-            </template>
-          </td>
-        </tr>
-      </template>
+                <template v-else-if="!dst && src">
+                  {{ src.tags?.[key] }}
+                </template>
+                <template v-else>
+                  {{ dst?.tags?.[key] }}
+                </template>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
     </template>
-  </table>
+  </div>
 </template>
 
 <style scoped>
-.item {
-  margin-top: 0.7em;
-  margin-right: 1.3em;
+.locha-diff {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: fit-content;
+}
+
+table {
+  table-layout: fixed;
+}
+
+table,
+th,
+td {
+  border: 1px solid #000000;
+  border-collapse: collapse;
+  padding: 0.15rem;
 }
 
 .diff-text-removed {
-  color: red;
+  color: v-bind('loChaColors.delete');
 }
 
 .diff-text-added {
-  color: rgb(0, 172, 0);
+  color: v-bind('loChaColors.new');
 }
 
 .diff-text-same {
   text-decoration: underline;
 }
 
-.attribute-removed {
-  background: rgb(255, 230, 230);
+.attribute-deleted {
+  background-color: color-mix(in srgb, v-bind('loChaColors.delete') 20%, #ffffff 80%);
 }
 
-.attribute-added {
-  background: rgb(232, 255, 232);
+.attribute-new {
+  background-color: color-mix(in srgb, v-bind('loChaColors.new') 20%, #ffffff 80%);
 }
 
 .attribute-changed {
-  background: lightgoldenrodyellow;
+  background-color: color-mix(in srgb, v-bind('loChaColors.updateAfter') 20%, #ffffff 80%);
+}
+
+.no_changes {
+  background-color: #f4f4f5;
 }
 
 td {
@@ -241,6 +234,5 @@ td.key {
 
 tr.no_changes {
   font-size: 70%;
-  background-color: var(--el-color-info-light-9);
 }
 </style>

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -217,9 +217,9 @@ function matchFilterBySelectors(selectors: string[]) {
             <LoCha :data="loCha">
               <template #tags-diff="{ diff, src, dst }">
                 <tags-diff
-                  v-if="diff && dst"
+                  v-if="diff"
                   :src-tags="src?.tags"
-                  :dst-tags="dst.tags"
+                  :dst-tags="dst?.tags"
                   :diff="diff"
                 />
               </template>

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -217,10 +217,9 @@ function matchFilterBySelectors(selectors: string[]) {
             <LoCha :data="loCha">
               <template #tags-diff="{ diff, src, dst }">
                 <tags-diff
-                  v-if="diff"
-                  :src-tags="src?.tags"
-                  :dst-tags="dst?.tags"
                   :diff="diff"
+                  :src="src"
+                  :dst="dst"
                 />
               </template>
               <template #link-metadata="{ links }">


### PR DESCRIPTION
## Summary
- Align `TagsDiff.vue` with the library's `LoChaDiff.vue` implementation
- Accept `src`/`dst` as `IFeature['properties']` instead of extracted tags
- Sort keys by diff type (added/removed/changed) like the library
- Handle before-only case (`src` without `dst`) showing plain tag list
- Remove Element Plus action badges in favor of simpler diff table
- Align CSS with library colors and styles (`loChaColors`, `color-mix`)
- Remove `v-if="diff && dst"` guard so diff renders on "before" features too

Closes #355

## Test plan
- [ ] Open a project changes_logs page with changes (e.g. `espana_navarra_aquitania_emergency`)
- [ ] Verify tag diff appears on both "before" (left) and "after" (right) features
- [ ] Before features show tags in plain list without icons or colors
- [ ] After features show full before/after diff with color coding and character-level diffs
- [ ] Verify CSS matches library demo (borders, `color-mix` backgrounds, font sizing)