### PR TITLE
fix: reset h3 and p margins inside LoCha objects

### DIFF
--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -278,4 +278,9 @@ function matchFilterBySelectors(selectors: string[]) {
   margin-right: 0.5em;
   margin-bottom: 0.3em;
 }
+
+:deep(.locha-object) h3,
+:deep(.locha-object) p {
+  margin: 0;
+}
 </style>

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -215,8 +215,13 @@ function matchFilterBySelectors(selectors: string[]) {
               </div>
             </template>
             <LoCha :data="loCha">
-              <template #tags-diff="{ diff, src, dst }">
+              <template #tags-diff="{ title, date, diff, dst, src }">
+                <div v-if="title || (dst?.is_after && src)" class="locha-infos">
+                  <span v-if="title" class="locha-title">🔗 {{ title }}</span>
+                  <span v-if="dst?.is_after && src" class="locha-date">📅 {{ date }}</span>
+                </div>
                 <tags-diff
+                  v-if="!dst?.deleted"
                   :diff="diff"
                   :src="src"
                   :dst="dst"
@@ -282,5 +287,16 @@ function matchFilterBySelectors(selectors: string[]) {
 :deep(.locha-object) h3,
 :deep(.locha-object) p {
   margin: 0;
+}
+
+.locha-infos {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.locha-title,
+.locha-date {
+  font-size: 12px;
+  color: grey;
 }
 </style>


### PR DESCRIPTION
## Summary
- Reset `h3` and `p` margins inside LoCha objects to match library demo (Element Plus adds extra margins)
- Add before-object reference link (`🔗 w1183954446-v4`) and date on after features, matching the library demo
- Skip diff rendering for deleted features (`!dst?.deleted`)

Closes #357

## Test plan
- [ ] Open a project changes_logs page
- [ ] Verify LoCha object headers have compact spacing matching the library demo
- [ ] Verify after features show `🔗` link to before-object reference and `📅` date
- [ ] Verify before features do not show the title/date info
- [ ] Verify deleted features do not show the tag diff table