### PR TITLE
fix: use plain CSS selector for LoCha object margins

### DIFF
--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -284,8 +284,8 @@ function matchFilterBySelectors(selectors: string[]) {
   margin-bottom: 0.3em;
 }
 
-:deep(.locha-object) h3,
-:deep(.locha-object) p {
+.locha-object h3,
+.locha-object p {
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
- `:deep()` has no effect in the unscoped `<style scope>` block (pre-existing typo for `<style scoped>`)
- Replace `:deep(.locha-object)` with plain `.locha-object` CSS selector so the margin reset actually applies

Closes #359

## Test plan
- [ ] Open a project changes_logs page
- [ ] Verify `h3` and `p` inside LoCha objects no longer have browser default margins