### PR TITLE
feat: restore action badges in tag diff groups

### DIFF
--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -125,31 +125,33 @@ function diffText(before: string, after: string): Change[] {
       :key="groupIndex"
     >
       <table v-if="groupedTagKeys.length">
-        <thead v-if="dst && getGroupActions(groupedKey)">
-          <tr>
-            <th colspan="3">
-              <el-tag
-                v-if="getGroupActions(groupedKey)?.length === 0"
-                type="warning"
-                size="small"
-                :disable-transitions="true"
-              >
-                ?
-              </el-tag>
-              <template v-else>
+        <thead v-if="dst">
+          <template v-for="(actions, ai) in [getGroupActions(groupedKey)]" :key="ai">
+            <tr v-if="actions">
+              <th colspan="3">
                 <el-tag
-                  v-for="(action, actionIndex) in getGroupActions(groupedKey)"
-                  :key="actionIndex"
-                  :type="action[1] === 'reject' ? 'danger' : 'info'"
+                  v-if="actions.length === 0"
+                  type="warning"
                   size="small"
                   :disable-transitions="true"
-                  class="action-tag"
                 >
-                  {{ action[0] }}
+                  ?
                 </el-tag>
-              </template>
-            </th>
-          </tr>
+                <template v-else>
+                  <el-tag
+                    v-for="(action, actionIndex) in actions"
+                    :key="actionIndex"
+                    :type="action[1] === 'reject' ? 'danger' : 'info'"
+                    size="small"
+                    :disable-transitions="true"
+                    class="action-tag"
+                  >
+                    {{ action[0] }}
+                  </el-tag>
+                </template>
+              </th>
+            </tr>
+          </template>
         </thead>
         <tbody>
           <template v-for="key in groupedKey" :key="key">

--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Actions, IFeature } from '@teritorio/openstreetmap-logical-history-component'
+import type { Action, Actions, IFeature } from '@teritorio/openstreetmap-logical-history-component'
 import type { Change } from 'diff'
 import { diffChars } from 'diff'
 import { groupBy, sortBy, uniq } from 'underscore'
@@ -101,6 +101,14 @@ function getRowClass(key: string): string | undefined {
   return isRejected(key) ? undefined : 'no_changes'
 }
 
+function getGroupActions(groupedKey: string[]): Action[] | undefined {
+  const key = groupedKey[0]
+  if (!key) {
+    return undefined
+  }
+  return props.diff?.[key] as Action[] | undefined
+}
+
 function showTextDiff(before: string, after: string): boolean {
   return diffText(before, after).length <= 2
 }
@@ -117,6 +125,32 @@ function diffText(before: string, after: string): Change[] {
       :key="groupIndex"
     >
       <table v-if="groupedTagKeys.length">
+        <thead v-if="dst && getGroupActions(groupedKey)">
+          <tr>
+            <th colspan="3">
+              <el-tag
+                v-if="getGroupActions(groupedKey)?.length === 0"
+                type="warning"
+                size="small"
+                :disable-transitions="true"
+              >
+                ?
+              </el-tag>
+              <template v-else>
+                <el-tag
+                  v-for="(action, actionIndex) in getGroupActions(groupedKey)"
+                  :key="actionIndex"
+                  :type="action[1] === 'reject' ? 'danger' : 'info'"
+                  size="small"
+                  :disable-transitions="true"
+                  class="action-tag"
+                >
+                  {{ action[0] }}
+                </el-tag>
+              </template>
+            </th>
+          </tr>
+        </thead>
         <tbody>
           <template v-for="key in groupedKey" :key="key">
             <tr :class="getRowClass(key)">
@@ -234,5 +268,9 @@ td.key {
 
 tr.no_changes {
   font-size: 70%;
+}
+
+.action-tag {
+  margin-right: 0.3em;
 }
 </style>


### PR DESCRIPTION
## Summary
- Re-add action type badges (e.g. `tags_changes_significant`, `tags_changes_non_significant`) as group headers in the tag diff table
- Badges are colored danger (reject) or info (accept) using Element Plus `el-tag`
- Only shown on "after" features (where `dst` exists)

Closes #361

## Test plan
- [ ] Open a project changes_logs page with changes
- [ ] Verify action badges appear above each group of tags in the diff
- [ ] Verify reject actions show red badges, accept actions show blue/grey badges
- [ ] Verify before features still show plain tag list without badges