### PR TITLE
fix: remove duplicate link-metadata wrapper and center content

### DIFF
--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -228,25 +228,23 @@ function matchFilterBySelectors(selectors: string[]) {
                 />
               </template>
               <template #link-metadata="{ links }">
-                <div v-if="links" class="link-metadata">
-                  <el-tag
-                    v-for="userGroup in uniq((links as ClearanceApiLink[]).flatMap((link) => link.matches.flatMap((m: ClearanceMatch) => m.user_groups)))"
-                    :key="userGroup"
-                    size="small"
-                    class="match-tag"
-                  >
-                    {{ userGroup }}
-                  </el-tag>
-                  <el-tag
-                    v-for="match in uniqMatches(links as ClearanceApiLink[])"
-                    :key="match.selectors.join(';')"
-                    size="small"
-                    type="warning"
-                    class="match-tag"
-                  >
-                    {{ match.selectors.join(' ') }}
-                  </el-tag>
-                </div>
+                <el-tag
+                  v-for="userGroup in uniq((links as ClearanceApiLink[]).flatMap((link) => link.matches.flatMap((m: ClearanceMatch) => m.user_groups)))"
+                  :key="userGroup"
+                  size="small"
+                  class="match-tag"
+                >
+                  {{ userGroup }}
+                </el-tag>
+                <el-tag
+                  v-for="match in uniqMatches(links as ClearanceApiLink[])"
+                  :key="match.selectors.join(';')"
+                  size="small"
+                  type="warning"
+                  class="match-tag"
+                >
+                  {{ match.selectors.join(' ') }}
+                </el-tag>
               </template>
             </LoCha>
           </el-card>
@@ -276,7 +274,7 @@ function matchFilterBySelectors(selectors: string[]) {
 }
 
 .link-metadata {
-  margin-bottom: 0.5em;
+  text-align: center;
 }
 
 .match-tag {


### PR DESCRIPTION
## Summary
- Remove duplicate `<div class="link-metadata">` — the library already wraps the `#link-metadata` slot content
- Center the tags horizontally with `text-align: center`

Closes #363

## Test plan
- [ ] Open a project changes_logs page
- [ ] Verify link-metadata tags (user groups, selectors) are centered horizontally
- [ ] Verify no double div wrapper in the DOM