### PR TITLE
feat: use maps.cartoway.com as tile source in DiffMap

### DIFF
--- a/app/components/DiffMap.vue
+++ b/app/components/DiffMap.vue
@@ -27,8 +27,7 @@ onMounted(() => {
   if (mapContainerRef.value) {
     const map = new Map({
       container: mapContainerRef.value,
-      style:
-      'https://vecto.teritorio.xyz/styles/teritorio-basic/style.json?key=teritorio_clearance-1-ahNoohaepohy9iexoo3qua',
+      style: 'https://maps.cartoway.com/styles/positron/style.json',
       bounds: bounds.value,
       fitBoundsOptions: { maxZoom: 17, padding: 50 },
       cooperativeGestures: true,


### PR DESCRIPTION
## Summary
- Replace `vecto.teritorio.xyz` with `maps.cartoway.com/styles/positron` in `DiffMap.vue`
- Unifies the tile source across the app (same as the LoCha library's `VMap`)

Closes #365

## Test plan
- [ ] Open a project changes_logs page
- [ ] Verify the top DiffMap renders correctly with the new tile source
- [ ] Verify map style matches the LoCha per-group maps