### PR TITLE
feat: use configurable map style URL via environment variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,6 @@
 COMPOSE_FILE=docker-compose.yaml
 
 NUXT_PUBLIC_API=https://clearance-dev.teritorio.xyz/api/0.1
-NUXT_PUBLIC_MAP_STYLE_URL=https://vecto.teritorio.xyz/styles/teritorio-basic/style.json?key=teritorio_clearance-1-ahNoohaepohy9iexoo3qua
+NUXT_PUBLIC_MAP_STYLE_URL=https://example.com/styles/positron/style.json
 NUXT_PUBLIC_SENTRY_DSN=
 NUXT_PUBLIC_SENTRY_ENVIRONMENT=production

--- a/.env.template
+++ b/.env.template
@@ -2,5 +2,6 @@
 COMPOSE_FILE=docker-compose.yaml
 
 NUXT_PUBLIC_API=https://clearance-dev.teritorio.xyz/api/0.1
+NUXT_PUBLIC_MAP_STYLE_URL=https://vecto.teritorio.xyz/styles/teritorio-basic/style.json?key=teritorio_clearance-1-ahNoohaepohy9iexoo3qua
 NUXT_PUBLIC_SENTRY_DSN=
 NUXT_PUBLIC_SENTRY_ENVIRONMENT=production

--- a/app/components/DiffMap.vue
+++ b/app/components/DiffMap.vue
@@ -23,12 +23,13 @@ const noChanges = ref(false)
 const bounds = ref<LngLatBounds>()
 const geometries = ref<Geometry[]>()
 
+const config = useRuntimeConfig()
+
 onMounted(() => {
   if (mapContainerRef.value) {
     const map = new Map({
       container: mapContainerRef.value,
-      style:
-      'https://vecto.teritorio.xyz/styles/teritorio-basic/style.json?key=teritorio_clearance-1-ahNoohaepohy9iexoo3qua',
+      style: config.public.mapStyleUrl as string,
       bounds: bounds.value,
       fitBoundsOptions: { maxZoom: 17, padding: 50 },
       cooperativeGestures: true,

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -214,7 +214,7 @@ function matchFilterBySelectors(selectors: string[]) {
                 </el-button-group>
               </div>
             </template>
-            <LoCha :data="loCha">
+            <LoCha :data="loCha" :map-style-url="config.public.mapStyleUrl as string">
               <template #tags-diff="{ title, date, diff, dst, src }">
                 <div v-if="title || (dst?.is_after && src)" class="locha-infos">
                   <span v-if="title" class="locha-title">🔗 {{ title }}</span>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     image: ghcr.io/teritorio/clearance-frontend:develop
     environment:
       - NUXT_PUBLIC_API=${NUXT_PUBLIC_API}
+      - NUXT_PUBLIC_MAP_STYLE_URL=${NUXT_PUBLIC_MAP_STYLE_URL}
       - NUXT_PUBLIC_SENTRY_DSN=${NUXT_PUBLIC_SENTRY_DSN}
       - NUXT_PUBLIC_SENTRY_ENVIRONMENT=${NUXT_PUBLIC_SENTRY_ENVIRONMENT}
     ports:

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,9 @@
 import process from 'node:process'
 
+if (!process.env.NUXT_PUBLIC_MAP_STYLE_URL) {
+  console.warn('WARNING: NUXT_PUBLIC_MAP_STYLE_URL is not set. Map tiles will not load.')
+}
+
 export default defineNuxtConfig({
   modules: ['@nuxt/eslint', '@element-plus/nuxt', '@nuxtjs/i18n', '@sentry/nuxt/module'],
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,6 +29,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       api: process.env.NUXT_PUBLIC_API,
+      mapStyleUrl: process.env.NUXT_PUBLIC_MAP_STYLE_URL,
       sentryDsn: process.env.NUXT_PUBLIC_SENTRY_DSN,
       sentryEnvironment: process.env.NUXT_PUBLIC_SENTRY_ENVIRONMENT,
     },


### PR DESCRIPTION
## Summary
- Add `NUXT_PUBLIC_MAP_STYLE_URL` environment variable for map tile source
- Use it in `DiffMap.vue` (replaces hardcoded vecto URL)
- Pass it to `LoCha` component via `mapStyleUrl` prop

Closes #367

## Test plan
- [ ] Set `NUXT_PUBLIC_MAP_STYLE_URL` in `.env`
- [ ] Verify DiffMap (top of page) uses the configured tile source
- [ ] Verify LoCha per-group maps use the configured tile source
- [ ] Verify changing the env var switches tile sources correctly