### PR TITLE
fix: sort tag diff groups by action priority (reject first)

### DIFF
--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Action, Actions, IFeature } from '@teritorio/openstreetmap-logical-history-component'
+import type { Action, Actions, ActionType, IFeature } from '@teritorio/openstreetmap-logical-history-component'
 import type { Change } from 'diff'
 import { diffChars } from 'diff'
 import { groupBy, sortBy, uniq } from 'underscore'
@@ -17,6 +17,14 @@ const loChaColors = {
   updateAfter: '#F2BE00',
 }
 
+function actionPriority(actionType: ActionType | null): number {
+  return actionType ? { reject: 2, accept: 0 }[actionType] : 1
+}
+
+function maxActionPriority(actions: Action[]): number {
+  return Math.max(...actions.map((action) => actionPriority(action[1])))
+}
+
 const groupedTagKeys = computed((): string[][] => {
   if (props.src && !props.dst) {
     return [Object.keys(props.src.tags)]
@@ -27,15 +35,7 @@ const groupedTagKeys = computed((): string[][] => {
       ...Object.keys(props.src?.tags || {}),
       ...Object.keys(props.dst?.tags || {}),
     ]),
-    (key: string) => {
-      return props.diff?.[key]
-        && (
-          !props.src?.tags || !(key in props.src.tags)
-            ? 0
-            : props.dst && !props.dst.tags[key]
-              ? 2
-              : 1)
-    },
+    (key: string) => (props.diff?.[key] ? -maxActionPriority(props.diff[key]) : 0),
   )
 
   return Object.values(

--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -18,7 +18,10 @@ const loChaColors = {
 }
 
 function actionPriority(actionType: ActionType | null): number {
-  return actionType ? { reject: 2, accept: 0 }[actionType] : 1
+  if (!actionType) {
+    return 1
+  }
+  return { reject: 2, accept: 0 }[actionType] ?? 1
 }
 
 function maxActionPriority(actions: Action[]): number {


### PR DESCRIPTION
## Summary

- Restore action-priority-based sorting in `TagsDiff.vue` that was lost during the LoCha integration refactor (`701db0e`)
- Groups with `reject` actions (`tags_changes_significant`) now appear before `accept` groups (`tags_changes_non_significant`), matching the original `Diff.vue` behavior

## Test plan

- [ ] Verify that `tags_changes_significant` tables appear before `tags_changes_non_significant` in the changes logs view
- [ ] Verify that tags with no diff still appear at the end

Closes #370