### PR TITLE
fix: set uniform column widths in TagsDiff tables

### DIFF
--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -128,6 +128,11 @@ function diffText(before: string, after: string): Change[] {
       :key="groupIndex"
     >
       <table v-if="groupedTagKeys.length">
+        <colgroup>
+          <col class="col-icon" />
+          <col class="col-key" />
+          <col class="col-value" />
+        </colgroup>
         <thead v-if="dst">
           <template v-for="(actions, ai) in [getGroupActions(groupedKey)]" :key="ai">
             <tr v-if="actions">
@@ -225,6 +230,18 @@ function diffText(before: string, after: string): Change[] {
 
 table {
   table-layout: fixed;
+}
+
+.col-icon {
+  width: 25px;
+}
+
+.col-key {
+  width: 130px;
+}
+
+.col-value {
+  width: auto;
 }
 
 table,

--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -128,6 +128,11 @@ function diffText(before: string, after: string): Change[] {
       :key="groupIndex"
     >
       <table v-if="groupedTagKeys.length">
+        <colgroup>
+          <col class="col-icon" />
+          <col class="col-key" />
+          <col />
+        </colgroup>
         <thead v-if="dst">
           <template v-for="(actions, ai) in [getGroupActions(groupedKey)]" :key="ai">
             <tr v-if="actions">
@@ -223,7 +228,16 @@ function diffText(before: string, after: string): Change[] {
 }
 
 table {
+  table-layout: fixed;
   width: 100%;
+}
+
+.col-icon {
+  width: 25px;
+}
+
+.col-key {
+  width: 130px;
 }
 
 table,

--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -128,11 +128,6 @@ function diffText(before: string, after: string): Change[] {
       :key="groupIndex"
     >
       <table v-if="groupedTagKeys.length">
-        <colgroup>
-          <col class="col-icon" />
-          <col class="col-key" />
-          <col class="col-value" />
-        </colgroup>
         <thead v-if="dst">
           <template v-for="(actions, ai) in [getGroupActions(groupedKey)]" :key="ai">
             <tr v-if="actions">
@@ -226,18 +221,6 @@ function diffText(before: string, after: string): Change[] {
   flex-direction: column;
   gap: 0.75rem;
   width: fit-content;
-}
-
-table {
-  table-layout: fixed;
-}
-
-.col-icon {
-  width: 25px;
-}
-
-.col-key {
-  width: 80px;
 }
 
 table,

--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -240,10 +240,6 @@ table {
   width: 130px;
 }
 
-.col-value {
-  width: auto;
-}
-
 table,
 th,
 td {

--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -220,7 +220,10 @@ function diffText(before: string, after: string): Change[] {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  width: fit-content;
+}
+
+table {
+  width: 100%;
 }
 
 table,

--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -237,7 +237,7 @@ table {
 }
 
 .col-key {
-  width: 130px;
+  width: 80px;
 }
 
 table,


### PR DESCRIPTION
## Summary

- Add `<colgroup>` with fixed column widths for consistent table layout across all tag diff groups
- Icon column (➕/~/✖): 25px
- Tag key column: 130px (covers most common OSM keys like `name`, `addr:street`, `opening_hours`, `contact:housenumber`)
- Tag value column: auto (takes remaining space)

## Test plan

- [ ] Verify all TagsDiff tables have uniform column widths
- [ ] Verify long tag keys (e.g. `sanitary_dump_station:chemical_toilet`) wrap properly
- [ ] Verify long tag values (URLs, descriptions) display correctly

Closes #372