### PR TITLE
fix: progressive loading of LoCha components on changes_logs page

### DIFF
--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -110,6 +110,7 @@ const loChasWithFilter = computed(() => {
 
 const visibleCount = ref(BATCH_SIZE)
 const sentinelRef = useTemplateRef<HTMLElement>('sentinel')
+let loading = false
 
 watch(loChasWithFilter, () => {
   visibleCount.value = BATCH_SIZE
@@ -124,28 +125,35 @@ const hasMore = computed(() => {
 })
 
 function loadMore() {
-  if (hasMore.value) {
-    visibleCount.value += BATCH_SIZE
+  if (loading || !hasMore.value) {
+    return
   }
+  loading = true
+  requestAnimationFrame(() => {
+    visibleCount.value += BATCH_SIZE
+    loading = false
+  })
 }
 
+let observer: IntersectionObserver | undefined
+
 onMounted(() => {
-  const observer = new IntersectionObserver((entries) => {
+  observer = new IntersectionObserver((entries) => {
     if (entries[0]?.isIntersecting) {
       loadMore()
     }
   })
 
   watch(sentinelRef, (el) => {
-    observer.disconnect()
+    observer!.disconnect()
     if (el) {
-      observer.observe(el)
+      observer!.observe(el)
     }
   }, { immediate: true })
+})
 
-  onUnmounted(() => {
-    observer.disconnect()
-  })
+onUnmounted(() => {
+  observer?.disconnect()
 })
 
 const atomUrl = computed(() => `${config.public.api}/projects/${projectSlug}/changes_logs.atom`)
@@ -342,6 +350,6 @@ function matchFilterBySelectors(selectors: string[]) {
 }
 
 .sentinel {
-  height: 1px;
+  min-height: 1px;
 }
 </style>

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -12,6 +12,8 @@ definePageMeta({
   },
 })
 
+const BATCH_SIZE = 3
+
 const router = useRouter()
 const route = useRoute()
 const projectSlug = route.params.project as string
@@ -103,6 +105,46 @@ const loChasWithFilter = computed(() => {
                 ))
       )
     })
+  })
+})
+
+const visibleCount = ref(BATCH_SIZE)
+const sentinelRef = useTemplateRef<HTMLElement>('sentinel')
+
+watch(loChasWithFilter, () => {
+  visibleCount.value = BATCH_SIZE
+})
+
+const visibleLoChas = computed(() => {
+  return loChasWithFilter.value.slice(0, visibleCount.value)
+})
+
+const hasMore = computed(() => {
+  return visibleCount.value < loChasWithFilter.value.length
+})
+
+function loadMore() {
+  if (hasMore.value) {
+    visibleCount.value += BATCH_SIZE
+  }
+}
+
+onMounted(() => {
+  const observer = new IntersectionObserver((entries) => {
+    if (entries[0]?.isIntersecting) {
+      loadMore()
+    }
+  })
+
+  watch(sentinelRef, (el) => {
+    observer.disconnect()
+    if (el) {
+      observer.observe(el)
+    }
+  }, { immediate: true })
+
+  onUnmounted(() => {
+    observer.disconnect()
   })
 })
 
@@ -201,7 +243,7 @@ function matchFilterBySelectors(selectors: string[]) {
       <template v-if="loChasWithFilter.length">
         <el-space fill :size="20">
           <el-card
-            v-for="loCha in loChasWithFilter"
+            v-for="loCha in visibleLoChas"
             :key="loCha.metadata.locha_id"
             style="--el-card-bg-color: #FAFAFA;"
           >
@@ -249,6 +291,7 @@ function matchFilterBySelectors(selectors: string[]) {
             </LoCha>
           </el-card>
         </el-space>
+        <div v-if="hasMore" ref="sentinel" class="sentinel" />
       </template>
       <el-empty
         v-else-if="data.loChas.length"
@@ -296,5 +339,9 @@ function matchFilterBySelectors(selectors: string[]) {
 .locha-date {
   font-size: 12px;
   color: grey;
+}
+
+.sentinel {
+  height: 1px;
 }
 </style>


### PR DESCRIPTION
## Summary

- Render only 3 LoCha cards initially instead of all (up to 1462)
- Load 3 more as the user scrolls via IntersectionObserver on a sentinel element
- Reset visible count when filters change

The API returns ~12MB / 1462 items for `france_landes_poi`. Rendering all LoCha components at once (each with a VMap/MapLibre GL instance) froze the browser.

Closes #376

## Test plan

- [ ] Open `/france_landes_poi/changes_logs` — page should load quickly with 3 cards visible
- [ ] Scroll down — new cards should appear progressively (3 at a time)
- [ ] Apply a filter — visible count should reset to 3
- [ ] Bulk validation still operates on all filtered items (not just visible ones)