### PR TITLE
fix: lazy load DiffMap to free WebGL context when off-screen

### DIFF
--- a/app/components/DiffMap.vue
+++ b/app/components/DiffMap.vue
@@ -18,132 +18,169 @@ const props = defineProps<{
   changeGeom?: Geometry[]
 }>()
 
-const mapContainerRef = shallowRef<InstanceType<typeof HTMLDivElement>>()
+const mapContainerRef = useTemplateRef<HTMLDivElement>('mapContainer')
 const noChanges = ref(false)
 const bounds = ref<LngLatBounds>()
 const geometries = ref<Geometry[]>()
 
 const config = useRuntimeConfig()
 
-onMounted(() => {
-  if (mapContainerRef.value) {
-    const map = new Map({
-      container: mapContainerRef.value,
-      style: config.public.mapStyleUrl as string,
-      bounds: bounds.value,
-      fitBoundsOptions: { maxZoom: 17, padding: 50 },
-      cooperativeGestures: true,
-      attributionControl: false,
-    })
+let map: Map | undefined
 
-    map.addControl(new FullscreenControl())
-
-    map.on('load', () => {
-      if (props.baseGeom) {
-        map.addSource('baseGeom', {
-          type: 'geojson',
-          data: {
-            type: 'GeometryCollection',
-            geometries: props.baseGeom,
-          },
-        })
-        // Point
-        map.addLayer({
-          id: 'baseGeomCircleBorder',
-          type: 'circle',
-          source: 'baseGeom',
-          filter: ['==', '$type', 'Point'],
-          paint: {
-            'circle-color': '#000',
-            'circle-radius': 10,
-          },
-        } as CircleLayerSpecification)
-        map.addLayer({
-          id: 'baseGeomCircle',
-          type: 'circle',
-          source: 'baseGeom',
-          filter: ['==', '$type', 'Point'],
-          paint: {
-            'circle-color': noChanges.value ? '#F0F0F0' : '#FF0000',
-            'circle-radius': 8,
-          },
-        } as CircleLayerSpecification)
-        // Linestring
-        map.addLayer({
-          id: 'baseGeomLineBorder',
-          type: 'line',
-          source: 'baseGeom',
-          filter: ['==', '$type', 'LineString'],
-          paint: {
-            'line-color': '#000',
-            'line-width': 4,
-          },
-        } as LineLayerSpecification)
-        map.addLayer({
-          id: 'baseGeomLine',
-          type: 'line',
-          source: 'baseGeom',
-          filter: ['==', '$type', 'LineString'],
-          paint: {
-            'line-color': noChanges.value ? '#F0F0F0' : '#FF0000',
-            'line-width': 3,
-          },
-        } as LineLayerSpecification)
-      }
-
-      if (props.changeGeom && !noChanges.value) {
-        map.addSource('changeGeom', {
-          type: 'geojson',
-          data: {
-            type: 'GeometryCollection',
-            geometries: props.changeGeom,
-          },
-        })
-        // Point
-        map.addLayer({
-          id: 'changeGeomCircleBorder',
-          type: 'circle',
-          source: 'changeGeom',
-          filter: ['==', '$type', 'Point'],
-          paint: {
-            'circle-color': '#000',
-            'circle-radius': 12,
-          },
-        } as CircleLayerSpecification)
-        map.addLayer({
-          id: 'changeGeomCircle',
-          type: 'circle',
-          source: 'changeGeom',
-          filter: ['==', '$type', 'Point'],
-          paint: {
-            'circle-color': '#FFBB00',
-            'circle-radius': 10,
-          },
-        } as CircleLayerSpecification)
-        // Linestring
-        map.addLayer({
-          id: 'changeGeomLineBorder',
-          type: 'line',
-          source: 'changeGeom',
-          filter: ['==', '$type', 'LineString'],
-          paint: {
-            'line-color': '#000',
-            'line-width': 6,
-          },
-        } as LineLayerSpecification)
-        map.addLayer({
-          id: 'changeGeomLine',
-          type: 'line',
-          source: 'changeGeom',
-          filter: ['==', '$type', 'LineString'],
-          paint: {
-            'line-color': '#FFBB00',
-            'line-width': 5,
-          },
-        } as LineLayerSpecification)
-      }
-    })
+function initMap() {
+  if (map || !mapContainerRef.value) {
+    return
   }
+
+  map = new Map({
+    container: mapContainerRef.value,
+    style: config.public.mapStyleUrl as string,
+    bounds: bounds.value,
+    fitBoundsOptions: { maxZoom: 17, padding: 50 },
+    cooperativeGestures: true,
+    attributionControl: false,
+  })
+
+  map.addControl(new FullscreenControl())
+
+  map.on('load', () => {
+    if (!map) {
+      return
+    }
+
+    if (props.baseGeom) {
+      map.addSource('baseGeom', {
+        type: 'geojson',
+        data: {
+          type: 'GeometryCollection',
+          geometries: props.baseGeom,
+        },
+      })
+      // Point
+      map.addLayer({
+        id: 'baseGeomCircleBorder',
+        type: 'circle',
+        source: 'baseGeom',
+        filter: ['==', '$type', 'Point'],
+        paint: {
+          'circle-color': '#000',
+          'circle-radius': 10,
+        },
+      } as CircleLayerSpecification)
+      map.addLayer({
+        id: 'baseGeomCircle',
+        type: 'circle',
+        source: 'baseGeom',
+        filter: ['==', '$type', 'Point'],
+        paint: {
+          'circle-color': noChanges.value ? '#F0F0F0' : '#FF0000',
+          'circle-radius': 8,
+        },
+      } as CircleLayerSpecification)
+      // Linestring
+      map.addLayer({
+        id: 'baseGeomLineBorder',
+        type: 'line',
+        source: 'baseGeom',
+        filter: ['==', '$type', 'LineString'],
+        paint: {
+          'line-color': '#000',
+          'line-width': 4,
+        },
+      } as LineLayerSpecification)
+      map.addLayer({
+        id: 'baseGeomLine',
+        type: 'line',
+        source: 'baseGeom',
+        filter: ['==', '$type', 'LineString'],
+        paint: {
+          'line-color': noChanges.value ? '#F0F0F0' : '#FF0000',
+          'line-width': 3,
+        },
+      } as LineLayerSpecification)
+    }
+
+    if (props.changeGeom && !noChanges.value) {
+      map.addSource('changeGeom', {
+        type: 'geojson',
+        data: {
+          type: 'GeometryCollection',
+          geometries: props.changeGeom,
+        },
+      })
+      // Point
+      map.addLayer({
+        id: 'changeGeomCircleBorder',
+        type: 'circle',
+        source: 'changeGeom',
+        filter: ['==', '$type', 'Point'],
+        paint: {
+          'circle-color': '#000',
+          'circle-radius': 12,
+        },
+      } as CircleLayerSpecification)
+      map.addLayer({
+        id: 'changeGeomCircle',
+        type: 'circle',
+        source: 'changeGeom',
+        filter: ['==', '$type', 'Point'],
+        paint: {
+          'circle-color': '#FFBB00',
+          'circle-radius': 10,
+        },
+      } as CircleLayerSpecification)
+      // Linestring
+      map.addLayer({
+        id: 'changeGeomLineBorder',
+        type: 'line',
+        source: 'changeGeom',
+        filter: ['==', '$type', 'LineString'],
+        paint: {
+          'line-color': '#000',
+          'line-width': 6,
+        },
+      } as LineLayerSpecification)
+      map.addLayer({
+        id: 'changeGeomLine',
+        type: 'line',
+        source: 'changeGeom',
+        filter: ['==', '$type', 'LineString'],
+        paint: {
+          'line-color': '#FFBB00',
+          'line-width': 5,
+        },
+      } as LineLayerSpecification)
+    }
+  })
+}
+
+function destroyMap() {
+  if (map) {
+    map.remove()
+    map = undefined
+  }
+}
+
+let observer: IntersectionObserver | undefined
+
+onMounted(() => {
+  observer = new IntersectionObserver((entries) => {
+    if (entries[0]?.isIntersecting) {
+      initMap()
+    }
+    else {
+      destroyMap()
+    }
+  })
+
+  if (mapContainerRef.value) {
+    observer.observe(mapContainerRef.value)
+  }
+})
+
+onUnmounted(() => {
+  observer?.disconnect()
+  destroyMap()
 })
 
 geometries.value = (props.baseGeom || props.changeGeom)!
@@ -169,7 +206,7 @@ if (geometries.value.length) {
 </script>
 
 <template>
-  <div ref="mapContainerRef" class="map" style="width: 100%; height: 200px" />
+  <div ref="mapContainer" class="map" style="width: 100%; height: 200px" />
 </template>
 
 <style>


### PR DESCRIPTION
## Summary

- DiffMap now uses IntersectionObserver to create/destroy the MapLibre GL map based on visibility
- When the user scrolls past the DiffMap, the map is destroyed and its WebGL context freed
- When scrolling back up, the map is recreated

This reduces the number of simultaneous WebGL contexts, mitigating "WebGL context was lost" errors when multiple LoCha VMap instances are visible below.

Closes #378

## Test plan

- [ ] Open `/france_landes_poi/changes_logs` — DiffMap renders normally at the top
- [ ] Scroll down past the DiffMap into the LoCha cards — DiffMap should be destroyed (check dev tools: WebGL context count decreases)
- [ ] Scroll back up — DiffMap should recreate with the same bounds and layers
- [ ] Verify LoCha VMap instances no longer lose WebGL context as quickly