### PR TITLE
feat: separate uninitialized projects into dedicated section

### DIFF
--- a/app/components/Project.vue
+++ b/app/components/Project.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { Project } from '~/libs/types'
+import type { InitializedProject } from '~/libs/types'
 
 const props = defineProps<{
-  project: Project
+  project: InitializedProject
 }>()
 
 const activeName = ref('')

--- a/app/components/ProjectLight.vue
+++ b/app/components/ProjectLight.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { HTMLTags, Project } from '~/libs/types'
+import type { HTMLTags, InitializedProject } from '~/libs/types'
 
 const props = defineProps<{
-  project: Project
+  project: InitializedProject
   titleTag: HTMLTags
 }>()
 

--- a/app/composables/useChangesLogs.ts
+++ b/app/composables/useChangesLogs.ts
@@ -1,5 +1,5 @@
 import type { ApiLink, LoChaData } from '@teritorio/openstreetmap-logical-history-component'
-import type { Project } from '~/libs/types'
+import type { InitializedProject } from '~/libs/types'
 
 export interface ClearanceMatch {
   sources: string[]
@@ -19,7 +19,7 @@ export interface ClearanceLoChaData extends LoChaData {
 }
 
 interface ChangesLogsData {
-  project: Project
+  project: InitializedProject
   loChas: ClearanceLoChaData[]
   fetchedAt: Date
 }
@@ -33,7 +33,7 @@ export function useChangesLogs(projectSlug: string) {
     async () => {
       try {
         const [project, loChas] = await Promise.all([
-          $fetch<Project>(`${config.public.api}/projects/${projectSlug}`),
+          $fetch<InitializedProject>(`${config.public.api}/projects/${projectSlug}`),
           $fetch<ClearanceLoChaData[]>(`${config.public.api}/projects/${projectSlug}/changes_logs`),
         ])
 

--- a/app/libs/types.ts
+++ b/app/libs/types.ts
@@ -69,7 +69,12 @@ export interface UserGroup {
   users: string[]
 }
 
-export interface Project {
+export interface UninitializedProject {
+  id: string
+  initialized: false
+}
+
+export interface InitializedProject {
   id: string
   title: MultilingualString
   description: MultilingualString
@@ -78,6 +83,12 @@ export interface Project {
   main_contacts: string[]
   user_groups: UserGroup[]
   project_tags: string[]
+}
+
+export type Project = UninitializedProject | InitializedProject
+
+export function isInitializedProject(project: Project): project is InitializedProject {
+  return !('initialized' in project && project.initialized === false)
 }
 
 export interface ProjectsResponse {
@@ -101,10 +112,10 @@ export function getProjects(apiEndpoint: string): Promise<ProjectsResponse> {
 export function getProject(
   apiEndpoint: string,
   project: string,
-): Promise<Project> {
+): Promise<InitializedProject> {
   return fetch(`${apiEndpoint}/projects/${project}`).then((data) => {
     if (data.ok) {
-      return data.json() as unknown as Project
+      return data.json() as unknown as InitializedProject
     }
     else {
       return Promise.reject(

--- a/app/pages/[project]/index.vue
+++ b/app/pages/[project]/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Project } from '~/libs/types'
+import type { InitializedProject } from '~/libs/types'
 import ProjectCompo from '~/components/Project.vue'
 import {
   getAsyncDataOrThrows,
@@ -16,7 +16,7 @@ definePageMeta({
 
 const params = useRoute().params
 const project: string = params.project as string
-const projectDetails = ref<Project>()
+const projectDetails = ref<InitializedProject>()
 const config = useRuntimeConfig()
 
 getAsyncDataOrThrows('fetchProject', () =>

--- a/app/pages/[project]/validators.vue
+++ b/app/pages/[project]/validators.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type {
-  Project,
+  InitializedProject,
   Validators as ValidatorsType,
 } from '~/libs/types'
 import {
@@ -21,7 +21,7 @@ definePageMeta({
 
 const params = useRoute().params
 const project: string = params.project as string
-const projectDetails = ref<Project>()
+const projectDetails = ref<InitializedProject>()
 const validators = ref<ValidatorsType>()
 const config = useRuntimeConfig()
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,16 +1,24 @@
 <script setup lang="ts">
-import type { Project } from '~/libs/types'
+import type { InitializedProject, Project, UninitializedProject } from '~/libs/types'
 import _ from 'underscore'
+import { isInitializedProject } from '~/libs/types'
 
 const admin = useAdmin()
 const user = useUser()
 const projects = useProjects()
-const myProjects = ref<Project[]>()
-const otherProjects = ref<Project[]>()
+const myProjects = ref<InitializedProject[]>()
+const otherProjects = ref<InitializedProject[]>()
+const uninitializedProjects = ref<UninitializedProject[]>()
+
+const [initialized, uninitialized] = _.partition(
+  projects.value,
+  (project: Project) => isInitializedProject(project),
+)
+uninitializedProjects.value = uninitialized as UninitializedProject[]
 
 const [my, other] = _.partition(
-  projects.value,
-  (project: Project) => user.value?.projects.includes(project.id) || false,
+  initialized as InitializedProject[],
+  (project: InitializedProject) => user.value?.projects.includes(project.id) || false,
 )
 myProjects.value = my
 otherProjects.value = other
@@ -74,6 +82,15 @@ otherProjects.value = other
       </template>
 
       <el-empty v-else :description="$t('page.index.empty')" :image-size="50" />
+
+      <template v-if="uninitializedProjects?.length">
+        <h2>{{ $t('page.index.uninitializedProjects') }}</h2>
+        <ul>
+          <li v-for="project in uninitializedProjects" :key="project.id">
+            {{ project.id }}
+          </li>
+        </ul>
+      </template>
     </el-container>
   </el-main>
 </template>

--- a/i18n/locales/en.js
+++ b/i18n/locales/en.js
@@ -22,6 +22,7 @@ export default {
     index: {
       myProjects: 'My projects',
       publicProjects: 'Public projects',
+      uninitializedProjects: 'Uninitialized projects',
       empty: 'No project',
     },
   },

--- a/i18n/locales/es.js
+++ b/i18n/locales/es.js
@@ -22,6 +22,7 @@ export default {
     index: {
       myProjects: 'Mis proyectos',
       publicProjects: 'Proyectos públicos',
+      uninitializedProjects: 'Proyectos no inicializados',
       empty: 'Sin proyecto',
     },
   },

--- a/i18n/locales/fr.js
+++ b/i18n/locales/fr.js
@@ -22,6 +22,7 @@ export default {
     index: {
       myProjects: 'Mes projets',
       publicProjects: 'Projets publics',
+      uninitializedProjects: 'Projets non initialisés',
       empty: 'Aucun projet',
     },
   },


### PR DESCRIPTION
## Summary
- Add `initialized` field to `Project` type
- Split uninitialized projects from the main list and display them in a separate section at the bottom of the index page
- Add translations (fr/en/es) for the new section heading

## Test plan
- [ ] Verify initialized projects appear in "Public projects" / "My projects"
- [ ] Verify uninitialized projects appear in the new "Uninitialized projects" section at the bottom
- [ ] Verify the section is hidden when there are no uninitialized projects