### PR TITLE
feat: add alternating background color on LoCha cards

### DIFF
--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -256,9 +256,9 @@ function matchFilterBySelectors(selectors: string[]) {
       <template v-if="loChasWithFilter.length">
         <el-space fill :size="20">
           <el-card
-            v-for="loCha in visibleLoChas"
+            v-for="(loCha, index) in visibleLoChas"
             :key="loCha.metadata.locha_id"
-            style="--el-card-bg-color: #FAFAFA;"
+            :style="{ '--el-card-bg-color': index % 2 === 0 ? '#f5f5f8' : '#e0e0e4' }"
           >
             <template v-if="isProjectUser" #header>
               <div class="card-header">

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -258,7 +258,7 @@ function matchFilterBySelectors(selectors: string[]) {
           <el-card
             v-for="(loCha, index) in visibleLoChas"
             :key="loCha.metadata.locha_id"
-            :style="{ '--el-card-bg-color': index % 2 === 0 ? '#f5f5f8' : '#e0e0e4' }"
+            :class="index % 2 === 0 ? 'locha-card-even' : 'locha-card-odd'"
           >
             <template v-if="isProjectUser" #header>
               <div class="card-header">
@@ -358,6 +358,14 @@ function matchFilterBySelectors(selectors: string[]) {
 .locha-date {
   font-size: 12px;
   color: grey;
+}
+
+.locha-card-even {
+  --el-card-bg-color: #f5f5f8;
+}
+
+.locha-card-odd {
+  --el-card-bg-color: #e0e0e4;
 }
 
 .sentinel {


### PR DESCRIPTION
## Summary

- Add alternating background colors (`#f5f5f8` / `#e0e0e4`) on LoCha cards for visual separation between consecutive groups

Closes #386

## Test plan

- [ ] Open a project's changes_logs page with multiple LoCha entries
- [ ] Verify cards alternate between two background shades
- [ ] Verify the alternation resets correctly when filters change the visible list

🤖 Generated with [Claude Code](https://claude.com/claude-code)