### PR TITLE
feat: restore changeset display via LoCha changesets slot

### DIFF
--- a/app/components/Changesets.vue
+++ b/app/components/Changesets.vue
@@ -1,19 +1,5 @@
 <script setup lang="ts">
-interface Changeset {
-  id: number
-  created_at: string
-  closed_at: string
-  open: boolean
-  user: string
-  uid: number
-  minlat: number
-  minlon: number
-  maxlat: number
-  maxlon: number
-  comments_count: number
-  changes_count: number
-  tags: Record<string, string>
-}
+import type { Changeset } from '~/libs/types'
 
 defineProps<{
   changesets: Changeset[]

--- a/app/components/Changesets.vue
+++ b/app/components/Changesets.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+interface Changeset {
+  id: number
+  created_at: string
+  closed_at: string
+  open: boolean
+  user: string
+  uid: number
+  minlat: number
+  minlon: number
+  maxlat: number
+  maxlon: number
+  comments_count: number
+  changes_count: number
+  tags: Record<string, string>
+}
+
+defineProps<{
+  changesets: Changeset[]
+}>()
+
+const accordion = ref('0')
+</script>
+
+<template>
+  <el-timeline>
+    <el-timeline-item
+      v-for="(changeset, index) in changesets"
+      :key="index"
+      :timestamp="changeset.created_at"
+      placement="top"
+    >
+      <p>
+        <span class="comment">✎ {{ changeset.tags.comment }}</span>
+        <br />
+        <template v-if="changeset.tags.source">
+          <span class="source">📷 {{ changeset.tags.source }}</span>
+          <br />
+        </template>
+        <span class="user">
+          👤&nbsp;<a
+            :href="`https://www.openstreetmap.org/user/${changeset.user}`"
+            target="_blank"
+          >{{ changeset.user }}</a>
+        </span>
+        <template v-if="changeset.tags.created_by">
+          <span class="created_by">🛠 {{ changeset.tags.created_by }}</span>
+          <br />
+        </template>
+        <el-collapse v-model="accordion" accordion>
+          <el-collapse-item :name="index">
+            <template #title>
+              ⯼&nbsp;<a
+                :href="`https://www.openstreetmap.org/changeset/${changeset.id}`"
+                target="_blank"
+              >{{ changeset.id }}</a>
+            </template>
+
+            <table>
+              <tr
+                v-for="[key, value] in Object.entries(changeset).filter(([k]) => k !== 'tags')"
+                :key="key"
+              >
+                <td>{{ key }}</td>
+                <td>{{ value }}</td>
+              </tr>
+            </table>
+
+            <table>
+              <tr
+                v-for="[key, value] in Object.entries(changeset.tags)"
+                :key="key"
+              >
+                <td>{{ key }}</td>
+                <td>{{ value }}</td>
+              </tr>
+            </table>
+          </el-collapse-item>
+        </el-collapse>
+      </p>
+    </el-timeline-item>
+  </el-timeline>
+</template>
+
+<style scoped>
+ul.el-timeline {
+  padding: 0;
+}
+
+:deep(.el-collapse div[role='button']) {
+  height: 1.5em;
+}
+
+.comment {
+  background-color: #f7f7ff;
+}
+
+.source {
+  background-color: #f7fff7;
+}
+
+.user {
+  background-color: #fff7f7;
+}
+
+.created_by {
+  background-color: #fffff7;
+}
+</style>

--- a/app/libs/types.ts
+++ b/app/libs/types.ts
@@ -28,6 +28,22 @@ export interface ObjectId {
   deleted: boolean
 }
 
+export interface Changeset {
+  id: number
+  created_at: string
+  closed_at: string
+  open: boolean
+  user: string
+  uid: number
+  minlat: number
+  minlon: number
+  maxlat: number
+  maxlon: number
+  comments_count: number
+  changes_count: number
+  tags: Record<string, string>
+}
+
 export interface User {
   osm_uid: number
   osm_name: string

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -289,6 +289,9 @@ function matchFilterBySelectors(selectors: string[]) {
                   :dst="dst"
                 />
               </template>
+              <template #changesets="{ changesets }">
+                <Changesets :changesets="changesets" />
+              </template>
               <template #link-metadata="{ links }">
                 <el-tag
                   v-for="userGroup in uniq((links as ClearanceApiLink[]).flatMap((link) => link.matches.flatMap((m: ClearanceMatch) => m.user_groups)))"


### PR DESCRIPTION
## Summary

- Re-create the `Changesets.vue` component with `el-timeline` layout (comment, source, user, tool, collapsible details)
- Use the LoCha `changesets` slot in `changes_logs.vue` to render it

Closes #388

## Test plan

- [ ] Open a project's changes_logs page with LoCha entries
- [ ] Verify each LoCha group now shows a fourth column with changeset timeline
- [ ] Verify changeset details are expandable via the accordion
- [ ] Verify OSM user and changeset links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)