### PR TITLE
fix: scope CSS styles in changes_logs page

### DIFF
--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -259,6 +259,7 @@ function matchFilterBySelectors(selectors: string[]) {
             v-for="(loCha, index) in visibleLoChas"
             :key="loCha.metadata.locha_id"
             :class="index % 2 === 0 ? 'locha-card-even' : 'locha-card-odd'"
+            style="--el-card-padding-body: 0;"
           >
             <template v-if="isProjectUser" #header>
               <div class="card-header">
@@ -328,13 +329,9 @@ function matchFilterBySelectors(selectors: string[]) {
   </el-main>
 </template>
 
-<style scope>
+<style scoped>
 .el-main {
   overflow: initial;
-}
-
-.el-card__body {
-  padding: 0;
 }
 
 .card-header {
@@ -343,22 +340,22 @@ function matchFilterBySelectors(selectors: string[]) {
   align-items: center;
 }
 
-.link-metadata {
+:deep(.link-metadata) {
   text-align: center;
 }
 
-.locha-object h3,
-.locha-object p {
+:deep(.locha-object h3),
+:deep(.locha-object p) {
   margin: 0;
 }
 
-.locha-infos {
+:deep(.locha-infos) {
   display: flex;
   gap: 0.5rem;
 }
 
-.locha-title,
-.locha-date {
+:deep(.locha-title),
+:deep(.locha-date) {
   font-size: 12px;
   color: grey;
 }


### PR DESCRIPTION
## Summary

- Fix `<style scope>` → `<style scoped>` (typo causing all styles to leak globally)
- Replace `.el-card__body { padding: 0 }` with `--el-card-padding-body: 0` CSS variable on the `el-card` element
- Add `:deep()` to selectors targeting child component elements (`.link-metadata`, `.locha-object`, `.locha-infos`, `.locha-title`, `.locha-date`)

## Test plan

- [ ] Verify LoCha cards still have no body padding
- [ ] Verify `el-card` components on other pages (e.g. index, project) are no longer affected by the padding override
- [ ] Verify link-metadata, locha-object, locha-infos styles still apply correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)