### PR TITLE
fix: use correct CSS variable --el-card-padding for card body

### DIFF
--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -259,7 +259,7 @@ function matchFilterBySelectors(selectors: string[]) {
             v-for="(loCha, index) in visibleLoChas"
             :key="loCha.metadata.locha_id"
             :class="index % 2 === 0 ? 'locha-card-even' : 'locha-card-odd'"
-            style="--el-card-padding-body: 0;"
+            style="--el-card-padding: 0;"
           >
             <template v-if="isProjectUser" #header>
               <div class="card-header">


### PR DESCRIPTION
## Summary

- Fix `--el-card-padding-body` → `--el-card-padding` (the correct Element Plus CSS variable for `.el-card__body` padding)

## Test plan

- [ ] Verify LoCha cards have no body padding on the changes_logs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)