### PR TITLE
fix: filter changesets per group based on linked features

### DIFF
--- a/app/components/Changesets.vue
+++ b/app/components/Changesets.vue
@@ -9,7 +9,10 @@ const accordion = ref('0')
 </script>
 
 <template>
-  <el-timeline>
+  <p v-if="changesets.length === 0" class="no-changesets">
+    {{ $t('changesets.no_changesets') }}
+  </p>
+  <el-timeline v-else>
     <el-timeline-item
       v-for="(changeset, index) in changesets"
       :key="index"
@@ -92,5 +95,11 @@ ul.el-timeline {
 
 .created_by {
   background-color: #fffff7;
+}
+
+.no-changesets {
+  color: grey;
+  font-size: 12px;
+  margin: 0;
 }
 </style>

--- a/app/components/Changesets.vue
+++ b/app/components/Changesets.vue
@@ -98,7 +98,7 @@ ul.el-timeline {
 }
 
 .no-changesets {
-  color: grey;
+  color: var(--el-text-color-secondary);
   font-size: 12px;
   margin: 0;
 }

--- a/app/composables/useChangesLogs.ts
+++ b/app/composables/useChangesLogs.ts
@@ -1,4 +1,4 @@
-import type { ApiLink, LoChaData } from '@teritorio/openstreetmap-logical-history-component'
+import type { ApiLink, IFeature, LoChaData } from '@teritorio/openstreetmap-logical-history-component'
 import type { InitializedProject } from '~/libs/types'
 
 export interface ClearanceMatch {
@@ -11,7 +11,14 @@ export interface ClearanceApiLink extends ApiLink {
   matches: ClearanceMatch[]
 }
 
+export interface ClearanceIFeature extends IFeature {
+  properties: IFeature['properties'] & {
+    changeset_id: number
+  }
+}
+
 export interface ClearanceLoChaData extends LoChaData {
+  features: ClearanceIFeature[]
   metadata: LoChaData['metadata'] & {
     locha_id: number
     links: ClearanceApiLink[][]

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -2,6 +2,7 @@
 import type { Action, IFeature } from '@teritorio/openstreetmap-logical-history-component'
 import type { Geometry } from 'geojson'
 import type { ClearanceApiLink, ClearanceLoChaData, ClearanceMatch } from '~/composables/useChangesLogs'
+import type { Changeset } from '~/libs/types'
 import { LoCha } from '@teritorio/openstreetmap-logical-history-component'
 import { uniq } from 'underscore'
 
@@ -237,6 +238,15 @@ async function resetFilters() {
 function matchFilterBySelectors(selectors: string[]) {
   return route.query.filterBySelectors !== undefined && selectors.includes(route.query.filterBySelectors as string)
 }
+
+function getGroupChangesets(loCha: ClearanceLoChaData, groupIndex: number): Changeset[] {
+  const changesetIds = new Set(
+    loCha.features
+      .filter((f) => f.properties.links === groupIndex)
+      .map((f) => f.properties.changeset_id),
+  )
+  return loCha.metadata.changesets.filter((c) => changesetIds.has(c.id))
+}
 </script>
 
 <template>
@@ -314,8 +324,8 @@ function matchFilterBySelectors(selectors: string[]) {
                   </template>
                 </template>
               </template>
-              <template #content-start>
-                <Changesets :changesets="loCha.metadata.changesets" />
+              <template #content-start="{ index: groupIndex }">
+                <Changesets :changesets="getGroupChangesets(loCha, groupIndex)" />
               </template>
               <template #header-center="{ index: groupIndex }">
                 <el-tag

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -2,7 +2,6 @@
 import type { Action, IFeature } from '@teritorio/openstreetmap-logical-history-component'
 import type { Geometry } from 'geojson'
 import type { ClearanceApiLink, ClearanceLoChaData, ClearanceMatch } from '~/composables/useChangesLogs'
-import type { Changeset } from '~/libs/types'
 import { LoCha } from '@teritorio/openstreetmap-logical-history-component'
 import { uniq } from 'underscore'
 
@@ -239,7 +238,7 @@ function matchFilterBySelectors(selectors: string[]) {
   return route.query.filterBySelectors !== undefined && selectors.includes(route.query.filterBySelectors as string)
 }
 
-function getGroupChangesets(loCha: ClearanceLoChaData, groupIndex: number): Changeset[] {
+function getGroupChangesets(loCha: ClearanceLoChaData, groupIndex: number) {
   const changesetIds = new Set(
     loCha.features
       .filter((f) => f.properties.links === groupIndex)

--- a/i18n/locales/en.js
+++ b/i18n/locales/en.js
@@ -69,5 +69,8 @@ export default {
     description: 'Description',
     other: 'Other',
   },
+  changesets: {
+    no_changesets: 'No changeset for this group.',
+  },
   atomFeed: 'Atom Feed',
 }

--- a/i18n/locales/es.js
+++ b/i18n/locales/es.js
@@ -69,5 +69,8 @@ export default {
     description: 'Descripción',
     other: 'Otro',
   },
+  changesets: {
+    no_changesets: 'No hay changeset para este grupo.',
+  },
   atomFeed: 'Fuente Atom',
 }

--- a/i18n/locales/fr.js
+++ b/i18n/locales/fr.js
@@ -69,5 +69,8 @@ export default {
     description: 'Description',
     other: 'Autre',
   },
+  changesets: {
+    no_changesets: 'Aucun changeset pour ce groupe.',
+  },
   atomFeed: 'Flux Atom',
 }


### PR DESCRIPTION
## Summary

- Add `ClearanceIFeature` type extending `IFeature` with `changeset_id: number` property
- Add `getGroupChangesets()` helper that filters changesets relevant to a given group by matching `feature.properties.links === groupIndex` and collecting their `changeset_id` values
- Update `#content-start` slot to receive `groupIndex` and pass filtered changesets to `<Changesets>`
- Add empty state message in `Changesets.vue` when no changesets match the group

## Test plan

- [ ] Open a LoCha with multiple groups (e.g. locha `81767872` from the issue)
- [ ] Verify group 0 shows changeset `160311696`
- [ ] Verify group 1 shows the "no changeset" message instead of `160311696`
- [ ] Verify a LoCha with a single group still shows its changeset correctly

Closes #394