### PR TITLE
fix: guard against null changesets

### DIFF
--- a/app/components/LogFilters.vue
+++ b/app/components/LogFilters.vue
@@ -56,7 +56,7 @@ const statUserGroups = computed(() => {
 const statUsers = computed(() => {
   const users = props.loChas
     .flatMap((loCha) =>
-      uniq(loCha.metadata.changesets.map((changeset) => changeset.user)),
+      uniq((loCha.metadata.changesets ?? []).map((changeset) => changeset.user)),
     )
   return getStats(users)
 })

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -90,7 +90,7 @@ const loChasWithFilter = computed(() => {
     return links.some((link: ClearanceApiLink) => {
       const changesetsUsers
         = route.query.filterByUsers !== undefined
-          && uniq(loCha.metadata.changesets.map((changeset) => changeset.user))
+          && uniq((loCha.metadata.changesets ?? []).map((changeset) => changeset.user))
 
       return (
         (route.query.filterByAction === undefined
@@ -244,7 +244,7 @@ function getGroupChangesets(loCha: ClearanceLoChaData, groupIndex: number) {
       .filter((f) => f.properties.links === groupIndex)
       .map((f) => f.properties.changeset_id),
   )
-  return loCha.metadata.changesets.filter((c) => changesetIds.has(c.id))
+  return (loCha.metadata.changesets ?? []).filter((c) => changesetIds.has(c.id))
 }
 </script>
 


### PR DESCRIPTION
Fixes #400

## Summary

- `loCha.metadata.changesets` can be `null` when no changesets exist (SQL `LEFT JOIN` + `jsonb_agg` returns null for empty sets)
- Added `?? []` null coalescing in 3 places to prevent crashes on projects like `morocco_poi`

## Test plan

- [ ] Load `morocco_poi` changes_logs — no crash
- [ ] Filter by user still works when changesets are present
- [ ] Changeset list per group still works