### PR TITLE
fix: disable el-tag animation in group-header

### DIFF
--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -387,10 +387,6 @@ function getGroupChangesets(loCha: ClearanceLoChaData, groupIndex: number) {
   animation: none !important;
 }
 
-:deep(.group-header) {
-  background-color: white;
-}
-
 :deep(.locha-object h3),
 :deep(.locha-object p) {
   margin: 0;

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -382,6 +382,15 @@ function getGroupChangesets(loCha: ClearanceLoChaData, groupIndex: number) {
   text-align: center;
 }
 
+:deep(.group-header .header-center .el-tag) {
+  transition: none !important;
+  animation: none !important;
+}
+
+:deep(.group-header) {
+  background-color: white;
+}
+
 :deep(.locha-object h3),
 :deep(.locha-object p) {
   margin: 0;


### PR DESCRIPTION
Closes #403

## Summary

Disable transition and animation on `.group-header .header-center .el-tag` elements via `:deep()\ CSS override.