### PR TITLE
fix: hide Changesets when empty, use column count to signal presence

### DIFF
--- a/app/components/Changesets.vue
+++ b/app/components/Changesets.vue
@@ -9,10 +9,7 @@ const accordion = ref('0')
 </script>
 
 <template>
-  <p v-if="changesets.length === 0" class="no-changesets">
-    {{ $t('changesets.no_changesets') }}
-  </p>
-  <el-timeline v-else>
+  <el-timeline v-if="changesets.length">
     <el-timeline-item
       v-for="(changeset, index) in changesets"
       :key="index"
@@ -95,11 +92,5 @@ ul.el-timeline {
 
 .created_by {
   background-color: #fffff7;
-}
-
-.no-changesets {
-  color: var(--el-text-color-secondary);
-  font-size: 12px;
-  margin: 0;
 }
 </style>

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -329,7 +329,10 @@ function getGroupChangesets(loCha: ClearanceLoChaData, groupIndex: number) {
                 </template>
               </template>
               <template #content-start="{ index: groupIndex }">
-                <Changesets :changesets="getGroupChangesets(loCha, groupIndex)" />
+                <Changesets
+                  v-if="getGroupChangesets(loCha, groupIndex).length"
+                  :changesets="getGroupChangesets(loCha, groupIndex)"
+                />
               </template>
               <template #header-center="{ index: groupIndex }">
                 <el-tag

--- a/i18n/locales/en.js
+++ b/i18n/locales/en.js
@@ -69,8 +69,5 @@ export default {
     description: 'Description',
     other: 'Other',
   },
-  changesets: {
-    no_changesets: 'No changeset for this group.',
-  },
   atomFeed: 'Atom Feed',
 }

--- a/i18n/locales/es.js
+++ b/i18n/locales/es.js
@@ -69,8 +69,5 @@ export default {
     description: 'Descripción',
     other: 'Otro',
   },
-  changesets: {
-    no_changesets: 'No hay changeset para este grupo.',
-  },
   atomFeed: 'Fuente Atom',
 }

--- a/i18n/locales/fr.js
+++ b/i18n/locales/fr.js
@@ -69,8 +69,5 @@ export default {
     description: 'Description',
     other: 'Autre',
   },
-  changesets: {
-    no_changesets: 'Aucun changeset pour ce groupe.',
-  },
   atomFeed: 'Flux Atom',
 }


### PR DESCRIPTION
Closes #406

## Summary

- Remove the "no changesets" empty state message from `Changesets.vue`
- Conditionally render the `Changesets` component only when changesets are present
- Results in 3-column layout when no changesets, 4-column layout when changesets exist
- Remove orphaned i18n keys (`changesets.no_changesets`) from en/fr/es locales