### PR TITLE
fix: table cell overflow in Firefox in TagsDiff

### DIFF
--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -266,7 +266,7 @@ function diffText(before: string, after: string): Change[] {
 }
 
 table {
-  table-layout: fixed;
+  table-layout: auto;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary

- Replace `table-layout: fixed` with `table-layout: auto` in `TagsDiff.vue`
- Firefox strictly distributes column widths equally under `fixed` layout (without explicit column widths), ignoring `white-space: nowrap` on `td.key`, causing cell content to overflow
- `auto` layout computes widths from content, fixing the overflow in Firefox without affecting Chrome/Brave

Same fix as teritorio/openstreetmap-logical-history-component#152.

Closes #417