### PR TITLE
fix: table overflows parent in TagsDiff with long values

### DIFF
--- a/app/components/TagsDiff.vue
+++ b/app/components/TagsDiff.vue
@@ -314,7 +314,7 @@ td {
 
 td {
   vertical-align: top;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 td.key {


### PR DESCRIPTION
## Summary

- Replace `overflow-wrap: break-word` with `overflow-wrap: anywhere` on `td` in `TagsDiff.vue`
- `break-word` does not affect minimum content width in `table-layout: auto`, so long values (URLs, long names) cause the table to expand beyond `width: 100%`
- `anywhere` reduces minimum content width to zero, constraining the table to its parent while still wrapping long content
- `white-space: nowrap` on `td.key` takes precedence, keeping keys on one line

Closes #419