### PR TITLE
feat: integrate Caddy proxy into docker-compose dev with mkcert

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,3 @@
-# For dev use: docker-compose.yaml:docker-compose.dev.yaml
-COMPOSE_FILE=docker-compose.yaml
-
 NUXT_PUBLIC_API=https://clearance-dev.teritorio.xyz/api/0.1
 NUXT_PUBLIC_MAP_STYLE_URL=https://example.com/styles/positron/style.json
 NUXT_PUBLIC_SENTRY_DSN=

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 .DS_Store
 .eslintcache
 .claude/
+.certs/
 
 # Yarn
 .pnp.*

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,18 +1,15 @@
-{
-	local_certs
-}
-
 clearance-dev.teritorio.xyz {
+	tls /certs/cert.pem /certs/key.pem
+
 	@backend path /api/* /users/* /up
 	handle @backend {
-		reverse_proxy https://164.132.128.58 {
-			header_up Host clearance-dev.teritorio.xyz
+		reverse_proxy https://clearance-dev.teritorio.xyz {
 			transport http {
 				tls_server_name clearance-dev.teritorio.xyz
 			}
 		}
 	}
 	handle {
-		reverse_proxy localhost:3000
+		reverse_proxy frontend:3000
 	}
 }

--- a/README.md
+++ b/README.md
@@ -35,39 +35,30 @@ In case the incoming changes from OpenStreetMap are desirable, the data can be a
 
 ## Installation
 
-### Setup
+### Requirements
 
-Make sure to install the dependencies:
+- [Docker](https://docs.docker.com/get-docker/)
 
-```bash
-yarn install
-```
+### Common Setup
 
-### Development Server
+Copy and configure the environment file (required for both dev and production):
 
-Create a fresh environment variable file
 ```bash
 cp .env.template .env # Set your variables accordingly
 ```
-Start development server on `http://localhost:3000`
-```bash
-# On local computer
-yarn dev
 
-# Or with Docker Compose
-docker compose up
-```
+### Development
 
-#### Local development with OSM OAuth (clearance-dev API)
+The dev workflow includes a Caddy reverse proxy for OSM OAuth support.
 
-To use OSM OAuth authentication locally against the `clearance-dev` API, you need a local HTTPS reverse proxy so the browser stays on the `clearance-dev.teritorio.xyz` domain (required for the session cookie and OAuth redirect to work).
+#### One-time setup
 
-**One-time setup:**
-
-1. Install [Caddy](https://caddyserver.com/) and trust its local CA:
+1. Install [mkcert](https://github.com/FiloSottile/mkcert) and generate a local certificate:
    ```bash
-   sudo pacman -S caddy   # Arch Linux
-   sudo caddy trust       # install Caddy's CA in system trust stores (run after first caddy start)
+   sudo pacman -S mkcert   # Arch Linux
+   mkcert -install         # installs the local CA in system trust stores
+   mkdir .certs
+   mkcert -cert-file .certs/cert.pem -key-file .certs/key.pem clearance-dev.teritorio.xyz
    ```
 
 2. Add to `/etc/hosts`:
@@ -75,22 +66,15 @@ To use OSM OAuth authentication locally against the `clearance-dev` API, you nee
    127.0.0.1 clearance-dev.teritorio.xyz
    ```
 
-3. A `Caddyfile` is already present at the project root.
-
-**Each session:**
+#### Each session
 
 ```bash
-yarn dev             # Nuxt dev server on :3000
-yarn proxy:start     # Caddy reverse proxy on :443
+yarn dev
 ```
 
-Then open `https://clearance-dev.teritorio.xyz` instead of `http://localhost:3000`.
+Then open `https://clearance-dev.teritorio.xyz` in your browser.
 
-```bash
-yarn proxy:stop      # stop Caddy when done
-```
-
-Caddy routes `/api/*` and `/users/*` to the real clearance-dev server and everything else to the Nuxt dev server.
+Caddy routes `/api/*` and `/users/*` to the remote clearance-dev server and everything else to the Nuxt dev server (with hot module replacement).
 
 #### ESLint config inspector
 
@@ -103,7 +87,7 @@ Visit http://localhost:7777/ to view and play with your ESLint config
 
 #### Setup Sentry
 
-Add DSN key and environment in .env file.
+Add DSN key and environment in `.env`:
 
 ```bash
 NUXT_PUBLIC_SENTRY_DSN="FILL THIS OUT"
@@ -112,16 +96,8 @@ NUXT_PUBLIC_SENTRY_ENVIRONMENT=production
 
 ### Production
 
-Build the application for production:
+Build and run with Docker Compose:
 
 ```bash
-yarn generate
-yarn start
-
-```
-
-Locally preview production build:
-
-```bash
-yarn preview
+docker compose up
 ```

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,5 +1,6 @@
 volumes:
   node_modules:
+
 services:
   frontend:
     build:
@@ -7,3 +8,23 @@ services:
     volumes:
       - .:/src
       - node_modules:/src/node_modules
+    command: npx nuxi dev --host 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"require('http').get('http://localhost:3000', r => process.exit(r.statusCode < 500 ? 0 : 1)).on('error', () => process.exit(1))\""]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
+
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./.certs:/certs:ro
+    depends_on:
+      frontend:
+        condition: service_healthy
+    restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -5,15 +5,13 @@
   "packageManager": "yarn@4.5.0",
   "scripts": {
     "build": "nuxi build",
-    "dev": "nuxi dev",
+    "dev": "docker compose -f docker-compose.dev.yaml up",
     "generate": "nuxi generate",
     "prepare": "simple-git-hooks && nuxi prepare",
     "preview": "nuxi preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "vitest",
-    "proxy:start": "sudo caddy start --config Caddyfile",
-    "proxy:stop": "sudo caddy stop"
+    "test": "vitest"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.2",


### PR DESCRIPTION
## Summary

- Replace manual `yarn proxy:start/stop` (host Caddy) with a `caddy` service in `docker-compose.dev.yaml` using bridge networking
- Use mkcert-generated certificates (stored in `.certs/`, gitignored) instead of Caddy's `local_certs`
- Update `Caddyfile` to use `frontend:3000` (inter-service Docker communication) and explicit `tls` cert paths
- Add `yarn dev:proxy` script as single entrypoint for the full dev stack with OSM OAuth
- Update README with revised one-time setup and daily workflow

## Test plan

- [ ] Install mkcert: `sudo pacman -S mkcert && mkcert -install`
- [ ] Generate certs: `mkdir .certs && mkcert -cert-file .certs/cert.pem -key-file .certs/key.pem clearance-dev.teritorio.xyz`
- [ ] Ensure `/etc/hosts` has `127.0.0.1 clearance-dev.teritorio.xyz`
- [ ] Run `yarn dev:proxy` and verify both containers start
- [ ] Open `https://clearance-dev.teritorio.xyz` — should serve the local Nuxt dev server
- [ ] Click "Connect via OSM" — OAuth flow should complete and redirect back to local frontend
- [ ] Verify API calls succeed (no CORS errors, cookie sent correctly)

Closes #421