### PR TITLE
fix: filter users by after-changesets only (#423)

### DIFF
--- a/app/components/LogFilters.vue
+++ b/app/components/LogFilters.vue
@@ -3,6 +3,7 @@ import type { Action } from '@teritorio/openstreetmap-logical-history-component'
 import type { LocationQuery } from 'vue-router'
 import type { ClearanceApiLink, ClearanceLoChaData, ClearanceMatch } from '~/composables/useChangesLogs'
 import { countBy, indexBy, sortBy, uniq } from 'underscore'
+import { getAfterUsers } from '~/composables/useChangesLogs'
 
 const props = defineProps<{
   loChas: ClearanceLoChaData[]
@@ -16,17 +17,11 @@ watchEffect(() => {
   filters.value = route.query
 })
 
-function allLinks(loChas: ClearanceLoChaData[]): ClearanceApiLink[] {
-  return loChas.flatMap((loCha) =>
-    loCha.metadata.links.flat(),
-  )
-}
-
 const stats = computed(() => {
   const actions = props.loChas
     .flatMap((loCha) =>
       uniq(
-        allLinks([loCha])
+        loCha.metadata.links.flat()
           .flatMap((link: ClearanceApiLink) => [
             ...Object.values(link.diff_attribs || {}),
             ...Object.values(link.diff_tags || {}),
@@ -40,7 +35,7 @@ const stats = computed(() => {
 
 const statSelectors = computed(() => {
   const matches = props.loChas.flatMap((loCha) =>
-    uniq(allLinks([loCha]).flatMap((link: ClearanceApiLink) => link.matches)).flat(),
+    uniq(loCha.metadata.links.flat().flatMap((link: ClearanceApiLink) => link.matches)).flat(),
   )
   return getStats(matches, (m: ClearanceMatch) => m.selectors.join(';'))
 })
@@ -48,18 +43,12 @@ const statSelectors = computed(() => {
 const statUserGroups = computed(() => {
   const userGroups = props.loChas
     .flatMap((loCha) =>
-      uniq(allLinks([loCha]).flatMap((link: ClearanceApiLink) => link.matches.flatMap((m) => m.user_groups))),
+      uniq(loCha.metadata.links.flat().flatMap((link: ClearanceApiLink) => link.matches.flatMap((m) => m.user_groups))),
     )
   return getStats(userGroups)
 })
 
-const statUsers = computed(() => {
-  const users = props.loChas
-    .flatMap((loCha) =>
-      uniq((loCha.metadata.changesets ?? []).map((changeset) => changeset.user)),
-    )
-  return getStats(users)
-})
+const statUsers = computed(() => getStats(props.loChas.flatMap(getAfterUsers)))
 
 const statDates = computed(() => {
   const dates = props.loChas.flatMap((loCha) =>

--- a/app/composables/useChangesLogs.ts
+++ b/app/composables/useChangesLogs.ts
@@ -1,5 +1,6 @@
 import type { ApiLink, IFeature, LoChaData } from '@teritorio/openstreetmap-logical-history-component'
 import type { InitializedProject } from '~/libs/types'
+import { uniq } from 'underscore'
 
 export interface ClearanceMatch {
   sources: string[]
@@ -23,6 +24,22 @@ export interface ClearanceLoChaData extends LoChaData {
     locha_id: number
     links: ClearanceApiLink[][]
   }
+}
+
+export function getAfterUsers(loCha: ClearanceLoChaData): string[] {
+  const afterFeatureIds = new Set(
+    loCha.metadata.links.flat().map((link) => link.after).filter(Boolean) as string[],
+  )
+  const afterChangesetIds = new Set(
+    loCha.features
+      .filter((f) => afterFeatureIds.has(f.id as string))
+      .map((f) => f.properties.changeset_id),
+  )
+  return uniq(
+    (loCha.metadata.changesets ?? [])
+      .filter((c) => afterChangesetIds.has(c.id))
+      .map((c) => c.user),
+  )
 }
 
 interface ChangesLogsData {

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -4,6 +4,7 @@ import type { Geometry } from 'geojson'
 import type { ClearanceApiLink, ClearanceLoChaData, ClearanceMatch } from '~/composables/useChangesLogs'
 import { LoCha } from '@teritorio/openstreetmap-logical-history-component'
 import { uniq } from 'underscore'
+import { getAfterUsers } from '~/composables/useChangesLogs'
 
 definePageMeta({
   validate({ params }) {
@@ -52,10 +53,6 @@ const isProjectUser = computed(() => {
   return !!user.value?.projects?.includes(projectSlug)
 })
 
-function getAllLinks(loCha: ClearanceLoChaData): ClearanceApiLink[] {
-  return loCha.metadata.links.flat()
-}
-
 function getFeatureLinks(loCha: ClearanceLoChaData, feature: IFeature, groupIndex: number): ClearanceApiLink[] {
   const links = loCha.metadata.links[groupIndex] as ClearanceApiLink[]
   if (feature.properties.is_before) {
@@ -91,40 +88,36 @@ const loChasWithFilter = computed(() => {
   }
 
   return data.value.loChas.filter((loCha: ClearanceLoChaData) => {
-    const links = getAllLinks(loCha)
-
-    return links.some((link: ClearanceApiLink) => {
-      const changesetsUsers
-        = route.query.filterByUsers !== undefined
-          && uniq((loCha.metadata.changesets ?? []).map((changeset) => changeset.user))
-
-      return (
-        (route.query.filterByAction === undefined
-          || [
-            ...Object.values(link.diff_attribs || {}),
-            ...Object.values(link.diff_tags || {}),
-          ].some(
-            (actions: Action[]) =>
-              actions?.some(
-                (action: Action) => action[0] === route.query.filterByAction,
-              ) || false,
+    if (route.query.filterByUsers !== undefined
+      && !getAfterUsers(loCha).includes(route.query.filterByUsers as string)) {
+      return false
+    }
+    if (route.query.filterByDate !== undefined
+      && !loCha.features.some((f) =>
+        !f.properties.is_before && f.properties.created?.substring(0, 10) === route.query.filterByDate,
+      )) {
+      return false
+    }
+    return loCha.metadata.links.flat().some((link: ClearanceApiLink) =>
+      (route.query.filterByAction === undefined
+        || [
+          ...Object.values(link.diff_attribs || {}),
+          ...Object.values(link.diff_tags || {}),
+        ].some(
+          (actions: Action[]) =>
+            actions?.some(
+              (action: Action) => action[0] === route.query.filterByAction,
+            ) || false,
+        ))
+        && (route.query.filterByUserGroups === undefined
+          || link.matches.some((match) =>
+            match.user_groups.includes(route.query.filterByUserGroups as string),
           ))
-          && (route.query.filterByUserGroups === undefined
+          && (route.query.filterBySelectors === undefined
             || link.matches.some((match) =>
-              match.user_groups.includes(route.query.filterByUserGroups as string),
-            ))
-            && (route.query.filterBySelectors === undefined
-              || link.matches.some((match) =>
-                matchFilterBySelectors(match.selectors),
-              ))
-              && (route.query.filterByUsers === undefined
-                || (changesetsUsers && changesetsUsers.includes(route.query.filterByUsers as string)))
-              && (route.query.filterByDate === undefined
-                || loCha.features.some((f) =>
-                  !f.properties.is_before && f.properties.created?.substring(0, 10) === route.query.filterByDate,
-                ))
-      )
-    })
+              matchFilterBySelectors(match.selectors),
+            )),
+    )
   })
 })
 


### PR DESCRIPTION
## Summary

- Regression from the LoCha migration: `filterByUsers` was matching LoChas where a user originally created the "before" object, not just the ones where they made the modification being reviewed
- Extract `getAfterUsers(loCha)` in `useChangesLogs.ts` as the single source of truth: resolves users via `links.after` feature IDs → their `changeset_id` → `metadata.changesets`, excluding before-state changesets
- Use `getAfterUsers` in both `LogFilters.vue` (`statUsers`) and `changes_logs.vue` (`loChasWithFilter`), ensuring filter buttons and actual filtering are always consistent
- Remove duplicate `getAllLinks`/`allLinks` helpers (inlined as `loCha.metadata.links.flat()`)
- Move loCha-level checks (user, date) outside the `links.some()` loop for early exit

## Test plan

- [ ] Filter by a user who only has "before" objects (original author, not the modifier) → should return 0 results
- [ ] Filter by a user who made modifications → should return their LoChas
- [ ] Filter button counts match the number of LoChas returned when clicking
- [ ] Date filter still works correctly
- [ ] No TypeScript errors (`yarn nuxt typecheck`)

Closes #423