### PR TITLE
feat: move validation buttons left

### DIFF
--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -406,6 +406,7 @@ function getGroupChangesets(loCha: ClearanceLoChaData, groupIndex: number) {
 .card-header {
   display: flex;
   align-items: center;
+  gap: 0.75rem;
   padding: 0.5rem 1rem;
 }
 

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -409,10 +409,6 @@ function getGroupChangesets(loCha: ClearanceLoChaData, groupIndex: number) {
   padding: 0.5rem 1rem;
 }
 
-.object-count {
-  margin-left: auto;
-}
-
 :deep(.header-center) {
   text-align: center;
 }

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -308,18 +308,18 @@ function getGroupChangesets(loCha: ClearanceLoChaData, groupIndex: number) {
           >
             <template v-if="getRapprochementsCount(loCha) > 1" #header>
               <div class="card-header">
-                <strong class="object-count">
-                  {{ $t('logs.rapprochements_count', { n: getRapprochementsCount(loCha) }) }}
-                </strong>
                 <el-button-group v-if="isProjectUser">
                   <el-button type="primary" @click="handleAccept([loCha.metadata.locha_id])">
                     ✓ {{ $t('logs.validate_locha') }}
                   </el-button>
                 </el-button-group>
+                <strong class="object-count">
+                  {{ $t('logs.rapprochements_count', { n: getRapprochementsCount(loCha) }) }}
+                </strong>
               </div>
             </template>
             <LoCha :id="String(loCha.metadata.locha_id)" :data="loCha" :map-style-url="config.public.mapStyleUrl as string" :hash="route.hash">
-              <template v-if="isProjectUser" #header-end>
+              <template v-if="isProjectUser" #header-start-end>
                 <el-button-group>
                   <el-button type="primary" @click="handleAccept([loCha.metadata.locha_id])">
                     ✓
@@ -409,7 +409,7 @@ function getGroupChangesets(loCha: ClearanceLoChaData, groupIndex: number) {
   padding: 0.5rem 1rem;
 }
 
-.card-header .el-button-group {
+.object-count {
   margin-left: auto;
 }
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@element-plus/icons-vue": "^2.3.2",
     "@element-plus/nuxt": "^1.1.5",
     "@sentry/nuxt": "^10.47.0",
-    "@teritorio/openstreetmap-logical-history-component": "0.6.1",
+    "@teritorio/openstreetmap-logical-history-component": "0.6.2",
     "@turf/bbox": "^7.3.4",
     "@turf/boolean-equal": "^7.3.4",
     "@turf/helpers": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@element-plus/icons-vue": "^2.3.2",
     "@element-plus/nuxt": "^1.1.5",
     "@sentry/nuxt": "^10.47.0",
-    "@teritorio/openstreetmap-logical-history-component": "0.6.0",
+    "@teritorio/openstreetmap-logical-history-component": "0.6.1",
     "@turf/bbox": "^7.3.4",
     "@turf/boolean-equal": "^7.3.4",
     "@turf/helpers": "^7.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4628,9 +4628,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@teritorio/openstreetmap-logical-history-component@npm:0.6.1":
-  version: 0.6.1
-  resolution: "@teritorio/openstreetmap-logical-history-component@npm:0.6.1"
+"@teritorio/openstreetmap-logical-history-component@npm:0.6.2":
+  version: 0.6.2
+  resolution: "@teritorio/openstreetmap-logical-history-component@npm:0.6.2"
   dependencies:
     "@sentry/vue": "npm:^10.44.0"
     "@turf/area": "npm:^7.3.4"
@@ -4647,7 +4647,7 @@ __metadata:
   peerDependencies:
     maplibre-gl: ^5.0.0
     vue: ^3.5.13
-  checksum: 10c0/b4bc797bc24e50ba1809bfa7d88746bce992261efecc29ced711e3c5a672c3965bcd4c51e66993d4e2b03386cf43a611620ffa405fad0619ec7fdf7ba47c1424
+  checksum: 10c0/4a9406d906c57d7e31f4458cec5489e4760d50d913a5c088fed9a2d548ad65eb8da849e16c87962d01c24d6cc9c559881bf1954e24f02f118b3c1eeae2b933f3
   languageName: node
   linkType: hard
 
@@ -14380,7 +14380,7 @@ __metadata:
     "@nuxt/test-utils": "npm:^3.19.1"
     "@nuxtjs/i18n": "npm:^10.2.4"
     "@sentry/nuxt": "npm:^10.47.0"
-    "@teritorio/openstreetmap-logical-history-component": "npm:0.6.1"
+    "@teritorio/openstreetmap-logical-history-component": "npm:0.6.2"
     "@turf/bbox": "npm:^7.3.4"
     "@turf/boolean-equal": "npm:^7.3.4"
     "@turf/helpers": "npm:^7.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4628,9 +4628,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@teritorio/openstreetmap-logical-history-component@npm:0.6.0":
-  version: 0.6.0
-  resolution: "@teritorio/openstreetmap-logical-history-component@npm:0.6.0"
+"@teritorio/openstreetmap-logical-history-component@npm:0.6.1":
+  version: 0.6.1
+  resolution: "@teritorio/openstreetmap-logical-history-component@npm:0.6.1"
   dependencies:
     "@sentry/vue": "npm:^10.44.0"
     "@turf/area": "npm:^7.3.4"
@@ -4647,7 +4647,7 @@ __metadata:
   peerDependencies:
     maplibre-gl: ^5.0.0
     vue: ^3.5.13
-  checksum: 10c0/29e5204b581cadd791de117166610d518d3bc6aa1f7ba25f23ef526ccd1586fb3a237b5a8cf1a1c722ae0f88f89e6e05ea69bb301f4ed0b86d95a7ad2189daa5
+  checksum: 10c0/b4bc797bc24e50ba1809bfa7d88746bce992261efecc29ced711e3c5a672c3965bcd4c51e66993d4e2b03386cf43a611620ffa405fad0619ec7fdf7ba47c1424
   languageName: node
   linkType: hard
 
@@ -14380,7 +14380,7 @@ __metadata:
     "@nuxt/test-utils": "npm:^3.19.1"
     "@nuxtjs/i18n": "npm:^10.2.4"
     "@sentry/nuxt": "npm:^10.47.0"
-    "@teritorio/openstreetmap-logical-history-component": "npm:0.6.0"
+    "@teritorio/openstreetmap-logical-history-component": "npm:0.6.1"
     "@turf/bbox": "npm:^7.3.4"
     "@turf/boolean-equal": "npm:^7.3.4"
     "@turf/helpers": "npm:^7.3.4"


### PR DESCRIPTION
Closes #428

## Summary

* Card-level button (LoCha): moved before the rapprochements counter instead of after it
* Group-level button: moved to the new `header-start-end` slot (after the 🔗 anchor, before the group name) instead of `header-end`
* Bumps `@teritorio/openstreetmap-logical-history-component` to 0.6.2 which adds the `header-start-end` slot with proper forwarding through `LoChaGroupList` and `LoCha`

## Test plan

- [ ] Visit a `changes_logs` page as a project user
- [ ] Verify card-level validate button appears on the left, counter on the right
- [ ] Verify group-level validate button appears between the 🔗 anchor and the group name
- [ ] Verify button still triggers validation correctly
- [ ] Verify visual layout when no button is shown (non-project user)