### PR TITLE
fix: prevent too much recursion on changes_logs accept action

### DIFF
--- a/app/composables/useChangesLogs.ts
+++ b/app/composables/useChangesLogs.ts
@@ -82,6 +82,7 @@ export function useChangesLogs(projectSlug: string) {
       }
     },
     {
+      deep: true,
       getCachedData(key): ChangesLogsData | undefined {
         const data = nuxtApp.payload.data[key] || nuxtApp.static.data[key]
 

--- a/app/pages/[project]/changes_logs.vue
+++ b/app/pages/[project]/changes_logs.vue
@@ -219,12 +219,9 @@ async function handleAccept(loChaIds?: number[]) {
     })
 
     if (data.value) {
-      data.value = {
-        ...data.value,
-        loChas: data.value.loChas.filter(
-          (loCha) => !loChaIds!.includes(loCha.metadata.locha_id),
-        ),
-      }
+      data.value.loChas = data.value.loChas.filter(
+        (loCha) => !loChaIds!.includes(loCha.metadata.locha_id),
+      )
     }
 
     ElMessage.success({


### PR DESCRIPTION
## Summary

Fixes #434

* Add `deep: true` to `useAsyncData` in `useChangesLogs` so the returned `data` ref uses `ref` instead of `shallowRef`, enabling reactivity on nested property mutations
* Revert the full object replacement (`data.value = { ...data.value, loChas: ... }`) introduced in 648c370e back to a direct array mutation (`data.value.loChas = ...`)

The previous workaround (object spread) forced reactivity under `shallowRef`, but caused a full re-render cascade of all child components on every accept action, ultimately triggering `InternalError: too much recursion` in Vue's scheduler.

## Test plan

- [ ] Open the `changes_logs` page of a project with pending entries
- [ ] Click "Validate" on a single entry — it should disappear without page errors
- [ ] Click "Validate all" (bulk) — all visible entries should disappear without recursion errors
- [ ] Verify the browser console shows no `InternalError: too much recursion`