### PR TITLE
fix: show world map when no user group polygons are available

### DIFF
--- a/app/components/UserGroups.vue
+++ b/app/components/UserGroups.vue
@@ -41,6 +41,9 @@ onMounted(() => {
           }
           return Promise.resolve(geojson)
         }
+        else {
+          console.error(`Failed to fetch polygon "${userGroup.polygon}": HTTP ${data.status}`)
+        }
       })
     })
 
@@ -49,18 +52,24 @@ onMounted(() => {
       type: 'FeatureCollection',
       features: _.compact(allPolygons),
     } as FeatureCollection
-    const bounds = new LngLatBounds(
-      bbox(geojson) as [number, number, number, number],
-    )
 
-    const map = new Map({
+    const mapOptions: ConstructorParameters<typeof Map>[0] = {
       container: mapContainer.value!,
       style: runtimeConfig.public.mapStyleUrl as string,
-      bounds,
-      fitBoundsOptions: { maxZoom: 20, padding: 50 },
       cooperativeGestures: true,
       attributionControl: false,
-    })
+    }
+
+    if (geojson.features.length > 0) {
+      mapOptions.bounds = new LngLatBounds(bbox(geojson) as [number, number, number, number])
+      mapOptions.fitBoundsOptions = { maxZoom: 20, padding: 50 }
+    }
+    else {
+      mapOptions.center = [0, 20]
+      mapOptions.zoom = 1
+    }
+
+    const map = new Map(mapOptions)
 
     map.on('load', () => {
       map.addSource('geojson', { type: 'geojson', data: geojson })

--- a/app/components/UserGroups.vue
+++ b/app/components/UserGroups.vue
@@ -39,11 +39,14 @@ onMounted(() => {
             geometry: await data.json(),
             properties: { color: userGroup.color },
           }
-          return Promise.resolve(geojson)
+          return geojson
         }
         else {
           console.error(`Failed to fetch polygon "${userGroup.polygon}": HTTP ${data.status}`)
         }
+      }).catch((err) => {
+        console.error(`Failed to fetch polygon "${userGroup.polygon}":`, err)
+        return undefined
       })
     })
 


### PR DESCRIPTION
## Summary

Fixes #433

* Guard against empty `FeatureCollection` before calling `turf/bbox` — an empty collection returns `[Infinity, Infinity, -Infinity, -Infinity]`, which causes MapLibre to crash with `Invalid LngLat latitude value`
* When no polygon features are available, initialize the map with a default world view (`center: [0, 20]`, `zoom: 1`) instead of computing `bounds`
* Log a `console.error` when a polygon fetch returns a non-2xx response

## Test plan

- [ ] Open a project page where no user group has a `polygon` defined — the map should render in world view without crashing
- [ ] Simulate a failed polygon fetch (e.g. by temporarily pointing to an invalid URL in the API response) — a `console.error` should appear, and the map should fall back to world view
- [ ] Open a project with valid polygons — the map should still fit to the polygon bounds as before